### PR TITLE
ci: drop macos-13 Intel Mac build from release matrix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,13 +45,6 @@ jobs:
             artifact-paths: |
               src-tauri/target/aarch64-apple-darwin/release/bundle/dmg/*.dmg
               src-tauri/target/aarch64-apple-darwin/release/bundle/macos/*.app.tar.gz
-          - os: macos-13
-            artifact-name: macos-x64-bundles
-            rust-target: x86_64-apple-darwin
-            tauri-args: --target x86_64-apple-darwin
-            artifact-paths: |
-              src-tauri/target/x86_64-apple-darwin/release/bundle/dmg/*.dmg
-              src-tauri/target/x86_64-apple-darwin/release/bundle/macos/*.app.tar.gz
           - os: windows-latest
             artifact-name: windows-bundles
             artifact-paths: |

--- a/docs/lessons_learnt.md
+++ b/docs/lessons_learnt.md
@@ -77,6 +77,13 @@ Gotchas, non-obvious behaviors, and key takeaways from closed issues.
 
 ---
 
+## chore/drop-macos-intel-build: Dropped macos-13 Release Matrix Cell
+
+**Key takeaways:**
+- GitHub Actions `macos-13` (Intel Mac) hosted runners are routinely queued 2h+ with no pickup, blocking the `release` job (which `needs: build` across the whole matrix). Apple stopped selling Intel Macs in 2023 and macOS Tahoe (2025) is the last macOS supporting them, so the Intel .dmg has a vanishing audience. Dropped the cell; arm64 still ships a signed .dmg. If Intel Mac support becomes important again, reintroduce with a self-hosted or third-party runner rather than hosted `macos-13`.
+
+---
+
 ## fix/ci-rollup-optional-deps: CI Rollup Optional Deps Fail on Non-Linux Runners
 
 **Key takeaways:**


### PR DESCRIPTION
## Summary
- Remove the \`macos-13\` cell from the release matrix; the hosted runner queues 2h+ with no pickup and blocks the release job indefinitely
- \`macos-latest\` (arm64) still ships a signed \`.dmg\` + \`.app.tar.gz\`

Closes #44

## Test plan
- [ ] Next push to main builds all three remaining matrix cells (linux, macos-arm64, windows) and completes the release job