### PR TITLE
Release v0.6.0

### DIFF
--- a/e2e/tab-title-git-root.spec.ts
+++ b/e2e/tab-title-git-root.spec.ts
@@ -1,0 +1,31 @@
+/**
+ * E2E: the "Git Repo Root in Tab Title" setting. When on, a folder inside a git
+ * repo shows the repo's root folder name; when off, the folder's own name.
+ * (Mock: /home/user/Documents/project is a git repo root.)
+ * Issue: feat/tab-title (git repo root in tab title)
+ */
+import { test, expect } from "@playwright/test";
+import { waitForEntries } from "./helpers";
+
+const NESTED = "/?path=/home/user/Documents/project/src";
+
+test.describe("Git repo root in tab title", () => {
+  test("shows the folder name when the setting is off (default)", async ({ page }) => {
+    await page.goto(NESTED);
+    await waitForEntries(page);
+    await expect(page.locator(".tab-title").first()).toHaveText("src");
+  });
+
+  test("shows the repo root name when the setting is on", async ({ page }) => {
+    await page.addInitScript(() => {
+      const k = "explorer-settings";
+      const s = JSON.parse(localStorage.getItem(k) || "{}");
+      s.tabTitleGitRoot = true;
+      localStorage.setItem(k, JSON.stringify(s));
+    });
+    await page.goto(NESTED);
+    await waitForEntries(page);
+    // Async: the repo root is resolved after first paint, then the title updates.
+    await expect(page.locator(".tab-title").first()).toHaveText("project");
+  });
+});

--- a/e2e/tab-title-git-root.spec.ts
+++ b/e2e/tab-title-git-root.spec.ts
@@ -1,31 +1,45 @@
 /**
- * E2E: the "Git Repo Root in Tab Title" setting. When on, a folder inside a git
- * repo shows the repo's root folder name; when off, the folder's own name.
+ * E2E: the "Git Repo Root in Tab Title" setting. When on, a tab inside a git
+ * repo shows a git icon and "repoRoot › currentFolder"; at the repo root it
+ * shows just the repo name. When off, the plain folder name.
  * (Mock: /home/user/Documents/project is a git repo root.)
  * Issue: feat/tab-title (git repo root in tab title)
  */
 import { test, expect } from "@playwright/test";
 import { waitForEntries } from "./helpers";
 
-const NESTED = "/?path=/home/user/Documents/project/src";
-
-test.describe("Git repo root in tab title", () => {
-  test("shows the folder name when the setting is off (default)", async ({ page }) => {
-    await page.goto(NESTED);
-    await waitForEntries(page);
-    await expect(page.locator(".tab-title").first()).toHaveText("src");
+const enableGitTitles = (page: import("@playwright/test").Page) =>
+  page.addInitScript(() => {
+    const k = "explorer-settings";
+    const s = JSON.parse(localStorage.getItem(k) || "{}");
+    s.tabTitleGitRoot = true;
+    localStorage.setItem(k, JSON.stringify(s));
   });
 
-  test("shows the repo root name when the setting is on", async ({ page }) => {
-    await page.addInitScript(() => {
-      const k = "explorer-settings";
-      const s = JSON.parse(localStorage.getItem(k) || "{}");
-      s.tabTitleGitRoot = true;
-      localStorage.setItem(k, JSON.stringify(s));
-    });
-    await page.goto(NESTED);
+test.describe("Git repo root in tab title", () => {
+  test("shows the plain folder name when the setting is off (default)", async ({ page }) => {
+    await page.goto("/?path=/home/user/Documents/project/src");
     await waitForEntries(page);
-    // Async: the repo root is resolved after first paint, then the title updates.
-    await expect(page.locator(".tab-title").first()).toHaveText("project");
+    await expect(page.locator(".tab-title").first()).toHaveText("src");
+    await expect(page.locator(".tab-icon-git")).toHaveCount(0);
+  });
+
+  test("shows a git icon and repo › folder for a subfolder when on", async ({ page }) => {
+    await enableGitTitles(page);
+    await page.goto("/?path=/home/user/Documents/project/src");
+    await waitForEntries(page);
+    // Repo root is resolved async after first paint; the title then updates.
+    await expect(page.locator(".tab-repo").first()).toHaveText("project");
+    await expect(page.locator(".tab-cwd").first()).toHaveText("src");
+    await expect(page.locator(".tab-icon-git").first()).toBeVisible();
+  });
+
+  test("shows just the repo name (no folder part) at the repo root when on", async ({ page }) => {
+    await enableGitTitles(page);
+    await page.goto("/?path=/home/user/Documents/project");
+    await waitForEntries(page);
+    await expect(page.locator(".tab-icon-git").first()).toBeVisible();
+    await expect(page.locator(".tab-cwd").first()).toHaveText("project");
+    await expect(page.locator(".tab-repo")).toHaveCount(0);
   });
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tauri-explorer",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "A minimalistic, high-performance file explorer",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5050,7 +5050,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-explorer"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tauri-explorer"
-version = "0.5.0"
+version = "0.6.0"
 description = "A minimalistic, high-performance file explorer"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "tauri-explorer",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "identifier": "com.explorer.app",
   "build": {
     "beforeDevCommand": "bun run dev",

--- a/src/lib/components/SettingsDialog.svelte
+++ b/src/lib/components/SettingsDialog.svelte
@@ -102,6 +102,7 @@
     millerHideEmpty: ["Hide Empty Folders in Miller View", "Don't show folders that have no visible entries in miller columns"],
     yaziNavigation: ["Yazi-style Navigation", "Left/right arrows navigate up/into folders in details and list view"],
     autoEnterSingleSubdir: ["Auto-Enter Single Subfolder", "When a folder contains only one subfolder (and nothing else), descend into it automatically"],
+    tabTitleGitRoot: ["Git Repo Root in Tab Title", "When the folder is inside a git repository, show the repo's root folder name in the tab title"],
     showManuallyHidden: ["Show Manually Hidden Items", "Reveal items hidden via the right-click Hide action (shown dimmed)"],
     gitStatus: ["Git Status Indicators", "Show modified/untracked indicators for files in git repositories"],
     recentItems: ["Recent Items in Sidebar", "Number of recent locations to show (0 to hide)"],
@@ -125,7 +126,7 @@
   ];
   const navBarRows = [rows.navBack, rows.navForward, rows.navUp, rows.navRefresh];
   const behaviorRows = [
-    rows.showHidden, rows.millerHideEmpty, rows.yaziNavigation, rows.autoEnterSingleSubdir, rows.showManuallyHidden,
+    rows.showHidden, rows.millerHideEmpty, rows.yaziNavigation, rows.autoEnterSingleSubdir, rows.tabTitleGitRoot, rows.showManuallyHidden,
     rows.gitStatus, rows.recentItems, rows.quickOpenDebug, rows.confirmDelete,
     rows.backgroundOpacity, rows.backgroundImage, rows.wallpaperBlur, rows.terminalApp,
     rows.previewFontSize, rows.ffmpegPath,
@@ -486,6 +487,21 @@
                 type="checkbox"
                 checked={settingsStore.autoEnterSingleSubdir}
                 onchange={() => settingsStore.update({ autoEnterSingleSubdir: !settingsStore.autoEnterSingleSubdir })}
+              />
+              <span class="toggle-slider"></span>
+            </label>
+          </div>
+
+          <div class="setting-row" class:hidden={!matchesSearch(...rows.tabTitleGitRoot)}>
+            <div class="setting-info">
+              <span class="setting-label">Git Repo Root in Tab Title</span>
+              <span class="setting-description">When the folder is inside a git repository, show the repo's root folder name in the tab title</span>
+            </div>
+            <label class="toggle">
+              <input
+                type="checkbox"
+                checked={settingsStore.tabTitleGitRoot}
+                onchange={() => settingsStore.update({ tabTitleGitRoot: !settingsStore.tabTitleGitRoot })}
               />
               <span class="toggle-slider"></span>
             </label>

--- a/src/lib/components/WindowTabBar.svelte
+++ b/src/lib/components/WindowTabBar.svelte
@@ -26,6 +26,17 @@
   const tabs = $derived(windowTabsManager.tabs);
   const activeTabId = $derived(windowTabsManager.activeTabId);
 
+  // When "git root in tab title" is on, resolve each tab's repo root (cached in
+  // the manager). Runs here because the async work needs a component owner; the
+  // manager's title derivation reacts to the cache it fills.
+  $effect(() => {
+    if (!settingsStore.tabTitleGitRoot) return;
+    for (const tab of windowTabsManager.tabs) {
+      const path = windowTabsManager.getTabPath(tab.id);
+      if (path) windowTabsManager.ensureGitRoot(path);
+    }
+  });
+
   let tabAreaRef = $state<HTMLElement | null>(null);
 
   function updateTabGap() {

--- a/src/lib/components/WindowTabBar.svelte
+++ b/src/lib/components/WindowTabBar.svelte
@@ -345,6 +345,7 @@
     bind:this={tabAreaRef}
   >
     {#each tabs as tab (tab.id)}
+      {@const display = windowTabsManager.getTabDisplay(tab)}
       <div
         class="tab"
         class:active={tab.id === activeTabId}
@@ -366,18 +367,48 @@
         ondragleave={handleTabDragLeave}
         ondrop={(e) => handleTabDrop(e, tab.id)}
       >
-        <svg
-          width="16"
-          height="16"
-          viewBox="0 0 16 16"
-          fill="none"
-          class="tab-icon"
-        >
-          <path
-            d="M2 3.5C2 2.67 2.67 2 3.5 2H6.17L8 3.83H12.5C13.33 3.83 14 4.5 14 5.33V12.5C14 13.33 13.33 14 12.5 14H3.5C2.67 14 2 13.33 2 12.5V3.5Z"
-          />
-        </svg>
-        <span class="tab-title">{windowTabsManager.getTabTitle(tab)}</span>
+        {#if display.isGitRoot}
+          <!-- Git branch icon: this tab's folder lives inside a git repo. -->
+          <svg
+            width="16"
+            height="16"
+            viewBox="0 0 16 16"
+            fill="none"
+            class="tab-icon tab-icon-git"
+            aria-label="Git repository"
+          >
+            <circle cx="4" cy="3.5" r="1.6" stroke="currentColor" stroke-width="1.3" />
+            <circle cx="4" cy="12.5" r="1.6" stroke="currentColor" stroke-width="1.3" />
+            <circle cx="11.5" cy="3.5" r="1.6" stroke="currentColor" stroke-width="1.3" />
+            <path
+              d="M4 5.1V10.9M11.5 5.1V6.5C11.5 8.2 10 9 8 9H6"
+              stroke="currentColor"
+              stroke-width="1.3"
+              stroke-linecap="round"
+            />
+          </svg>
+        {:else}
+          <svg
+            width="16"
+            height="16"
+            viewBox="0 0 16 16"
+            fill="none"
+            class="tab-icon"
+          >
+            <path
+              d="M2 3.5C2 2.67 2.67 2 3.5 2H6.17L8 3.83H12.5C13.33 3.83 14 4.5 14 5.33V12.5C14 13.33 13.33 14 12.5 14H3.5C2.67 14 2 13.33 2 12.5V3.5Z"
+            />
+          </svg>
+        {/if}
+        <span class="tab-title">
+          {#if display.repo}
+            <!-- Repo name shrinks/ellipsizes first; the current folder stays
+                 visible as long as possible (full path is in the tooltip). -->
+            <span class="tab-repo">{display.repo}</span>
+            <span class="tab-sep" aria-hidden="true">›</span>
+          {/if}
+          <span class="tab-cwd">{display.name}</span>
+        </span>
         <button
           class="tab-close"
           onclick={(e) => handleTabClose(e, tab.id)}
@@ -616,11 +647,56 @@
   }
 
   .tab-title {
+    display: flex;
+    align-items: baseline;
+    gap: 3px;
     max-width: 150px;
+    min-width: 0;
     overflow: hidden;
-    text-overflow: ellipsis;
     white-space: nowrap;
     transition: color var(--transition-fast);
+  }
+
+  /* Repo name is context: dimmed, and it's the first thing to shrink/ellipsize
+     (high flex-shrink) so the current folder stays readable. */
+  .tab-repo {
+    flex: 0 1 auto;
+    flex-shrink: 999;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    opacity: 0.6;
+  }
+
+  .tab-sep {
+    flex: 0 0 auto;
+    opacity: 0.5;
+  }
+
+  /* Current folder: shrinks only after the repo has fully collapsed. */
+  .tab-cwd {
+    flex: 0 1 auto;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  /* Git icon uses stroked shapes in the accent colour (override the folder
+     icon's fill rule, which would otherwise fill the branch glyph). */
+  .tab-icon-git {
+    color: var(--accent);
+    opacity: 0.85;
+  }
+
+  .tab-icon-git path,
+  .tab-icon-git circle {
+    fill: none;
+    stroke: currentColor;
+  }
+
+  .tab:hover .tab-icon-git,
+  .tab.active .tab-icon-git {
+    opacity: 1;
   }
 
   .tab-close {

--- a/src/lib/domain/tab-title.ts
+++ b/src/lib/domain/tab-title.ts
@@ -24,7 +24,7 @@ function segments(path: string): string[] {
 /** Label shown for a single item given the parent segments needed to make it
  *  unique within its collision group (empty when the bare basename suffices). */
 function formatLabel(base: string, parents: string[]): string {
-  return parents.length > 0 ? `${base} — ${parents.join("/")}` : base;
+  return parents.length > 0 ? `${base} · ${parents.join("/")}` : base;
 }
 
 /**

--- a/src/lib/domain/tab-title.ts
+++ b/src/lib/domain/tab-title.ts
@@ -1,0 +1,74 @@
+/**
+ * Tab title disambiguation (VS Code style).
+ *
+ * A tab's title is the basename of its folder. When two open tabs would show
+ * the same basename (e.g. two different `components` folders), we append just
+ * enough of each one's parent path to tell them apart — the shortest trailing
+ * segment(s) that make every colliding tab unique. Tabs whose basename is
+ * already unique keep the bare name.
+ *
+ * Pure and synchronous so the caller can feed it whatever "identity path" it
+ * likes (the folder itself, or a git repo root) and unit-test the result.
+ */
+
+export interface TabTitleItem {
+  id: string;
+  /** The path whose basename is the title; parents disambiguate collisions. */
+  path: string;
+}
+
+function segments(path: string): string[] {
+  return path.split(/[/\\]/).filter(Boolean);
+}
+
+/** Label shown for a single item given the parent segments needed to make it
+ *  unique within its collision group (empty when the bare basename suffices). */
+function formatLabel(base: string, parents: string[]): string {
+  return parents.length > 0 ? `${base} — ${parents.join("/")}` : base;
+}
+
+/**
+ * Map each item id to its display label, disambiguating shared basenames by the
+ * shortest distinguishing parent path.
+ */
+export function disambiguateTabTitles(items: TabTitleItem[]): Map<string, string> {
+  const result = new Map<string, string>();
+
+  // Group items by basename; only colliding groups need disambiguation.
+  const groups = new Map<string, TabTitleItem[]>();
+  for (const item of items) {
+    const segs = segments(item.path);
+    const base = segs[segs.length - 1] ?? item.path;
+    const group = groups.get(base);
+    if (group) group.push(item);
+    else groups.set(base, [item]);
+  }
+
+  for (const [base, group] of groups) {
+    if (group.length === 1) {
+      result.set(group[0].id, base);
+      continue;
+    }
+
+    const segArrays = group.map((it) => segments(it.path));
+    const maxLen = Math.max(...segArrays.map((a) => a.length));
+
+    // Smallest tail length k (≥2, includes the basename) that makes every
+    // colliding item's tail unique. If the paths are identical it never
+    // separates — clamp to the full path and let them share a label.
+    let k = 2;
+    for (; k < maxLen; k++) {
+      const tails = segArrays.map((a) => a.slice(-k).join("/"));
+      if (new Set(tails).size === group.length) break;
+    }
+
+    group.forEach((item, i) => {
+      const segs = segArrays[i];
+      // Parent segments inside the distinguishing tail, excluding the basename.
+      const parents = segs.slice(Math.max(0, segs.length - k), segs.length - 1);
+      result.set(item.id, formatLabel(base, parents));
+    });
+  }
+
+  return result;
+}

--- a/src/lib/state/settings.svelte.ts
+++ b/src/lib/state/settings.svelte.ts
@@ -89,6 +89,7 @@ export interface Settings {
   previewFontSize: number; // base font size (px) for text/code/markdown previews
   autoEnterSingleSubdir: boolean; // when entering a dir with exactly one visible subdir (and nothing else), descend into it recursively
   ffmpegPath: string; // explicit path to ffmpeg binary for video/audio thumbnails (empty = auto-detect)
+  tabTitleGitRoot: boolean; // when the folder is inside a git repo, show the repo root name in the tab title
 }
 
 const MIN_ZOOM = 50;
@@ -141,6 +142,7 @@ const DEFAULT_SETTINGS: Settings = {
   previewFontSize: 12,
   autoEnterSingleSubdir: false,
   ffmpegPath: "",
+  tabTitleGitRoot: false,
 };
 
 const STORAGE_KEY = "explorer-settings";
@@ -393,6 +395,9 @@ function createSettingsStore() {
     get ffmpegPath() {
       return settings.ffmpegPath;
     },
+    get tabTitleGitRoot() {
+      return settings.tabTitleGitRoot;
+    },
     toggleMillerColumns(): void {
       const on = settings.millerLayers > 0;
       update({ millerLayers: on ? 0 : settings.millerLayersPreferred });
@@ -506,6 +511,7 @@ export const TOGGLE_SETTINGS: ToggleSettingMeta[] = [
   { key: "quickOpenDebug", id: "view.toggleQuickOpenDebug", label: "Toggle Quick Open Debug Scores" },
   { key: "yaziNavigation", label: "Toggle Yazi Navigation" },
   { key: "autoEnterSingleSubdir", label: "Toggle Auto-Enter Single Subfolder" },
+  { key: "tabTitleGitRoot", label: "Toggle Git Repo Root in Tab Title" },
   { key: "integratedTitleBar", label: "Toggle Integrated Title Bar" },
   { key: "macOsVibrancy", label: "Toggle macOS Vibrancy" },
   { key: "vibrancyBlur", label: "Toggle Vibrancy Blur" },

--- a/src/lib/state/window-tabs.svelte.ts
+++ b/src/lib/state/window-tabs.svelte.ts
@@ -13,7 +13,7 @@
 import type { PaneId, WindowTab, WindowTabPane } from "./types";
 import { createExplorerState, type ExplorerInstance } from "./explorer.svelte";
 import { loadPersisted, savePersisted, removePersisted } from "./persisted";
-import { parentDir, directoryKey } from "$lib/domain/path";
+import { parentDir, directoryKey, basename } from "$lib/domain/path";
 import { disambiguateTabTitles } from "$lib/domain/tab-title";
 import { settingsStore } from "./settings.svelte";
 import { gitRepoRoot } from "$lib/api/files";
@@ -175,30 +175,71 @@ function createWindowTabsManager() {
   /** Get the currently active tab */
   const activeTab = $derived(tabs.find((t) => t.id === activeTabId) ?? null);
 
-  /** The path whose basename titles a tab: the git repo root when the setting
-   *  is on and the folder is inside a repo, otherwise the folder itself. */
-  function tabIdentityPath(tab: WindowTab): string {
-    const cwd = getPanePath(tab.panes[tab.activePaneId]);
-    if (settingsStore.tabTitleGitRoot) {
-      const root = gitRoots.get(directoryKey(cwd));
-      if (root) return root;
-    }
-    return cwd;
+  /** How a tab labels itself.
+   *  - git mode (setting on + folder inside a repo): a git icon, the repo root
+   *    name, and the current folder (`repo` is null when the cwd *is* the root).
+   *  - normal mode: a folder icon and the (disambiguated) folder name. */
+  interface TabDisplay {
+    isGitRoot: boolean;
+    repo: string | null;
+    name: string;
   }
 
-  /** Disambiguated title per tab (VS Code style): bare folder name, with just
-   *  enough parent path to tell same-named tabs apart. Reactive on tab paths,
-   *  the git-root cache, and the setting. */
-  const tabDisplayTitles = $derived.by(() =>
-    disambiguateTabTitles(tabs.map((t) => ({ id: t.id, path: tabIdentityPath(t) })))
-  );
+  /** Per-tab display info. Normal-mode tabs are disambiguated against each other
+   *  (VS Code style); git-mode tabs carry repo + cwd, which is already distinct.
+   *  Reactive on tab paths, the git-root cache, and the setting. */
+  const tabDisplays = $derived.by((): Map<string, TabDisplay> => {
+    const useGit = settingsStore.tabTitleGitRoot;
+    const normal: { id: string; path: string }[] = [];
+    const gitMode = new Map<string, { repoRoot: string; cwd: string }>();
 
-  /** Get tab title (active pane's folder, disambiguated; repo root if enabled). */
+    for (const t of tabs) {
+      const cwd = getPanePath(t.panes[t.activePaneId]);
+      const root = useGit ? gitRoots.get(directoryKey(cwd)) : null;
+      if (root) gitMode.set(t.id, { repoRoot: root, cwd });
+      else normal.push({ id: t.id, path: cwd });
+    }
+
+    const disamb = disambiguateTabTitles(normal);
+    const out = new Map<string, TabDisplay>();
+    for (const t of tabs) {
+      const g = gitMode.get(t.id);
+      if (g) {
+        const atRoot = directoryKey(g.cwd) === directoryKey(g.repoRoot);
+        out.set(t.id, {
+          isGitRoot: true,
+          repo: atRoot ? null : basename(g.repoRoot),
+          name: atRoot ? basename(g.repoRoot) : basename(g.cwd),
+        });
+      } else {
+        out.set(t.id, {
+          isGitRoot: false,
+          repo: null,
+          name: disamb.get(t.id) ?? extractFolderName(getPanePath(t.panes[t.activePaneId])),
+        });
+      }
+    }
+    return out;
+  });
+
+  /** Structured display (icon + repo + name) for rendering a tab. */
+  function getTabDisplay(tab: WindowTab): TabDisplay {
+    return (
+      tabDisplays.get(tab.id) ?? {
+        isGitRoot: false,
+        repo: null,
+        name: extractFolderName(getPanePath(tab.panes[tab.activePaneId])),
+      }
+    );
+  }
+
+  /** Plain-text tab title (used for the drag ghost and width measurement). */
   function getTabTitle(tab: WindowTab): string {
     const pane = tab.panes[tab.activePaneId];
     const explorer = explorers.get(pane.explorerId);
     if (!explorer) return pane.title || "Explorer";
-    return tabDisplayTitles.get(tab.id) ?? extractFolderName(explorer.currentPath);
+    const d = getTabDisplay(tab);
+    return d.repo ? `${d.repo} › ${d.name}` : d.name;
   }
 
   /** Fetch (and cache) the git repo root for a folder. No-op unless the
@@ -740,6 +781,7 @@ function createWindowTabsManager() {
     prevTab,
     reorderTabs,
     getTabTitle,
+    getTabDisplay,
     getTabPath,
     getTabTooltip,
     ensureGitRoot,

--- a/src/lib/state/window-tabs.svelte.ts
+++ b/src/lib/state/window-tabs.svelte.ts
@@ -13,7 +13,10 @@
 import type { PaneId, WindowTab, WindowTabPane } from "./types";
 import { createExplorerState, type ExplorerInstance } from "./explorer.svelte";
 import { loadPersisted, savePersisted, removePersisted } from "./persisted";
-import { parentDir } from "$lib/domain/path";
+import { parentDir, directoryKey } from "$lib/domain/path";
+import { disambiguateTabTitles } from "$lib/domain/tab-title";
+import { settingsStore } from "./settings.svelte";
+import { gitRepoRoot } from "$lib/api/files";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 
 /** Tauri window label, or "main" outside Tauri (browser E2E, tests). */
@@ -110,6 +113,12 @@ function createWindowTabsManager() {
   let tabs = $state<WindowTab[]>([]);
   let activeTabId = $state<string | null>(null);
 
+  // Cache of folder → git repo root (string), or null when not in a repo.
+  // Populated lazily by ensureGitRoot (driven from the tab bar) only while the
+  // "git root in tab title" setting is on. Keyed by directoryKey(path).
+  let gitRoots = $state(new Map<string, string | null>());
+  const gitRootPending = new Set<string>();
+
   // Stack of recently closed tabs for Ctrl+Shift+T restoration (persisted)
   let closedTabStack: ClosedTabSnapshot[] = loadPersisted<ClosedTabSnapshot[]>(CLOSED_TABS_KEY, []);
 
@@ -166,12 +175,45 @@ function createWindowTabsManager() {
   /** Get the currently active tab */
   const activeTab = $derived(tabs.find((t) => t.id === activeTabId) ?? null);
 
-  /** Get tab title (shows active pane's folder name) - derived from explorer's current path */
+  /** The path whose basename titles a tab: the git repo root when the setting
+   *  is on and the folder is inside a repo, otherwise the folder itself. */
+  function tabIdentityPath(tab: WindowTab): string {
+    const cwd = getPanePath(tab.panes[tab.activePaneId]);
+    if (settingsStore.tabTitleGitRoot) {
+      const root = gitRoots.get(directoryKey(cwd));
+      if (root) return root;
+    }
+    return cwd;
+  }
+
+  /** Disambiguated title per tab (VS Code style): bare folder name, with just
+   *  enough parent path to tell same-named tabs apart. Reactive on tab paths,
+   *  the git-root cache, and the setting. */
+  const tabDisplayTitles = $derived.by(() =>
+    disambiguateTabTitles(tabs.map((t) => ({ id: t.id, path: tabIdentityPath(t) })))
+  );
+
+  /** Get tab title (active pane's folder, disambiguated; repo root if enabled). */
   function getTabTitle(tab: WindowTab): string {
     const pane = tab.panes[tab.activePaneId];
     const explorer = explorers.get(pane.explorerId);
     if (!explorer) return pane.title || "Explorer";
-    return extractFolderName(explorer.currentPath);
+    return tabDisplayTitles.get(tab.id) ?? extractFolderName(explorer.currentPath);
+  }
+
+  /** Fetch (and cache) the git repo root for a folder. No-op unless the
+   *  setting is on and we haven't already resolved/queued this folder. Called
+   *  from the tab bar so the async work has a component owner. */
+  async function ensureGitRoot(path: string): Promise<void> {
+    if (!settingsStore.tabTitleGitRoot || !path) return;
+    const key = directoryKey(path);
+    if (gitRoots.has(key) || gitRootPending.has(key)) return;
+    gitRootPending.add(key);
+    const result = await gitRepoRoot(path);
+    gitRootPending.delete(key);
+    const root = result.ok ? result.data : null;
+    // Reassign for reactivity so tabDisplayTitles recomputes.
+    gitRoots = new Map(gitRoots).set(key, root);
   }
 
   /** Get path for a pane from its explorer */
@@ -700,6 +742,7 @@ function createWindowTabsManager() {
     getTabTitle,
     getTabPath,
     getTabTooltip,
+    ensureGitRoot,
 
     // Explorer access
     getExplorer,

--- a/tests/domain/tab-title.test.ts
+++ b/tests/domain/tab-title.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import { disambiguateTabTitles } from "../../src/lib/domain/tab-title";
+
+describe("disambiguateTabTitles", () => {
+  it("uses the bare folder name when basenames are unique", () => {
+    const r = disambiguateTabTitles([
+      { id: "a", path: "/home/user/Pictures" },
+      { id: "b", path: "/home/user/Documents" },
+    ]);
+    expect(r.get("a")).toBe("Pictures");
+    expect(r.get("b")).toBe("Documents");
+  });
+
+  it("appends the parent folder when two tabs share a basename", () => {
+    const r = disambiguateTabTitles([
+      { id: "a", path: "/work/featureA/components" },
+      { id: "b", path: "/work/featureB/components" },
+    ]);
+    expect(r.get("a")).toBe("components — featureA");
+    expect(r.get("b")).toBe("components — featureB");
+  });
+
+  it("walks further up when the immediate parents also collide", () => {
+    const r = disambiguateTabTitles([
+      { id: "a", path: "/x/shared/src" },
+      { id: "b", path: "/y/shared/src" },
+    ]);
+    expect(r.get("a")).toBe("src — x/shared");
+    expect(r.get("b")).toBe("src — y/shared");
+  });
+
+  it("only disambiguates the colliding group, leaving unique tabs bare", () => {
+    const r = disambiguateTabTitles([
+      { id: "a", path: "/work/featureA/components" },
+      { id: "b", path: "/work/featureB/components" },
+      { id: "c", path: "/home/user/Music" },
+    ]);
+    expect(r.get("a")).toBe("components — featureA");
+    expect(r.get("b")).toBe("components — featureB");
+    expect(r.get("c")).toBe("Music");
+  });
+
+  it("handles Windows backslash paths", () => {
+    const r = disambiguateTabTitles([
+      { id: "a", path: "C:\\proj\\app\\src" },
+      { id: "b", path: "C:\\proj\\lib\\src" },
+    ]);
+    expect(r.get("a")).toBe("src — app");
+    expect(r.get("b")).toBe("src — lib");
+  });
+
+  it("gives identical paths the same label without looping", () => {
+    const r = disambiguateTabTitles([
+      { id: "a", path: "/repo" },
+      { id: "b", path: "/repo" },
+    ]);
+    expect(r.get("a")).toBe("repo");
+    expect(r.get("b")).toBe("repo");
+  });
+});

--- a/tests/domain/tab-title.test.ts
+++ b/tests/domain/tab-title.test.ts
@@ -16,8 +16,8 @@ describe("disambiguateTabTitles", () => {
       { id: "a", path: "/work/featureA/components" },
       { id: "b", path: "/work/featureB/components" },
     ]);
-    expect(r.get("a")).toBe("components — featureA");
-    expect(r.get("b")).toBe("components — featureB");
+    expect(r.get("a")).toBe("components · featureA");
+    expect(r.get("b")).toBe("components · featureB");
   });
 
   it("walks further up when the immediate parents also collide", () => {
@@ -25,8 +25,8 @@ describe("disambiguateTabTitles", () => {
       { id: "a", path: "/x/shared/src" },
       { id: "b", path: "/y/shared/src" },
     ]);
-    expect(r.get("a")).toBe("src — x/shared");
-    expect(r.get("b")).toBe("src — y/shared");
+    expect(r.get("a")).toBe("src · x/shared");
+    expect(r.get("b")).toBe("src · y/shared");
   });
 
   it("only disambiguates the colliding group, leaving unique tabs bare", () => {
@@ -35,8 +35,8 @@ describe("disambiguateTabTitles", () => {
       { id: "b", path: "/work/featureB/components" },
       { id: "c", path: "/home/user/Music" },
     ]);
-    expect(r.get("a")).toBe("components — featureA");
-    expect(r.get("b")).toBe("components — featureB");
+    expect(r.get("a")).toBe("components · featureA");
+    expect(r.get("b")).toBe("components · featureB");
     expect(r.get("c")).toBe("Music");
   });
 
@@ -45,8 +45,8 @@ describe("disambiguateTabTitles", () => {
       { id: "a", path: "C:\\proj\\app\\src" },
       { id: "b", path: "C:\\proj\\lib\\src" },
     ]);
-    expect(r.get("a")).toBe("src — app");
-    expect(r.get("b")).toBe("src — lib");
+    expect(r.get("a")).toBe("src · app");
+    expect(r.get("b")).toBe("src · lib");
   });
 
   it("gives identical paths the same label without looping", () => {


### PR DESCRIPTION
Cuts v0.6.0. Changes since v0.5.0:

- **Ctrl+P**: results under the current folder show cwd-relative paths.
- **Pickers** (Ctrl+P / Ctrl+Shift+P / Ctrl+Shift+F): hover ignores mouse drift; selection only follows a deliberate move.
- **Tab titles**: optional git-repo-root mode (git icon + `repo › cwd`, repo shrinks first when long); VS Code-style disambiguation of same-named folders (`name · parent`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)