### PR TITLE
CI fixes: rustfmt/clippy sweep + perf-check config

### DIFF
--- a/scripts/perf-check.ts
+++ b/scripts/perf-check.ts
@@ -54,7 +54,7 @@ function parseBenchmarkOutput(output: string): BenchmarkEntry[] {
 
 function runBenchmarks(): BenchmarkEntry[] {
   console.log("Running benchmarks...\n");
-  const output = execSync("npx vitest run tests/perf/ 2>&1", {
+  const output = execSync("npx vitest run -c vitest.perf.config.ts tests/perf/ 2>&1", {
     encoding: "utf-8",
     timeout: 60000,
   });

--- a/src-tauri/src/ai_organize.rs
+++ b/src-tauri/src/ai_organize.rs
@@ -39,16 +39,15 @@ pub async fn ai_suggest_destination(
     let count = count.clamp(1, 5) as usize;
     let prompt = build_prompt(&file_name, content_hint.as_deref(), &candidates, count);
 
-    let raw =
-        match tokio::time::timeout(SUGGEST_TIMEOUT, run_gemini(&prompt, &api_key)).await {
-            Ok(result) => result?,
-            Err(_) => {
-                return Err(AppError::Other(format!(
-                    "AI destination suggestion timed out after {} seconds",
-                    SUGGEST_TIMEOUT.as_secs()
-                )))
-            }
-        };
+    let raw = match tokio::time::timeout(SUGGEST_TIMEOUT, run_gemini(&prompt, &api_key)).await {
+        Ok(result) => result?,
+        Err(_) => {
+            return Err(AppError::Other(format!(
+                "AI destination suggestion timed out after {} seconds",
+                SUGGEST_TIMEOUT.as_secs()
+            )))
+        }
+    };
 
     let suggestions = clean_destinations(&raw, &candidates, count);
     if suggestions.is_empty() {
@@ -185,7 +184,10 @@ mod tests {
     fn strips_markers_fences_and_quotes() {
         let candidates = cands(&["/a/b", "/c/d"]);
         let raw = "```\n1. \"/a/b\"\n- `/c/d`\n```";
-        assert_eq!(clean_destinations(raw, &candidates, 5), vec!["/a/b", "/c/d"]);
+        assert_eq!(
+            clean_destinations(raw, &candidates, 5),
+            vec!["/a/b", "/c/d"]
+        );
     }
 
     #[test]

--- a/src-tauri/src/ai_rename.rs
+++ b/src-tauri/src/ai_rename.rs
@@ -35,16 +35,16 @@ pub async fn ai_suggest_filenames(
     let count = count.clamp(1, 5) as usize;
     let prompt = build_prompt(&original_name, content_hint.as_deref(), count);
 
-    let raw = match tokio::time::timeout(SUGGEST_TIMEOUT, run_gemini_suggest(&prompt, &api_key)).await
-    {
-        Ok(result) => result?,
-        Err(_) => {
-            return Err(AppError::Other(format!(
-                "AI rename timed out after {} seconds",
-                SUGGEST_TIMEOUT.as_secs()
-            )))
-        }
-    };
+    let raw =
+        match tokio::time::timeout(SUGGEST_TIMEOUT, run_gemini_suggest(&prompt, &api_key)).await {
+            Ok(result) => result?,
+            Err(_) => {
+                return Err(AppError::Other(format!(
+                    "AI rename timed out after {} seconds",
+                    SUGGEST_TIMEOUT.as_secs()
+                )))
+            }
+        };
 
     let suggestions = clean_suggestions(&raw, &original_name, count);
     if suggestions.is_empty() {

--- a/src-tauri/src/clipboard.rs
+++ b/src-tauri/src/clipboard.rs
@@ -282,7 +282,7 @@ fn parse_applescript_png(text: &str) -> Option<Vec<u8>> {
         .chars()
         .filter(|c| c.is_ascii_hexdigit())
         .collect();
-    if hex.len() < 16 || hex.len() % 2 != 0 {
+    if hex.len() < 16 || !hex.len().is_multiple_of(2) {
         return None;
     }
     let bytes: Option<Vec<u8>> = (0..hex.len())

--- a/src-tauri/src/git_log.rs
+++ b/src-tauri/src/git_log.rs
@@ -27,7 +27,7 @@
 //! Every command runs under `spawn_blocking` and is cancellable through the
 //! shared `TaskRegistry`, mirroring `git.rs`.
 
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
@@ -202,7 +202,7 @@ fn build_log(
     opts: &GitLogOptions,
     cancelled: &AtomicBool,
 ) -> Result<GitLogPage, AppError> {
-    let limit = opts.limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT).max(1);
+    let limit = opts.limit.unwrap_or(DEFAULT_LIMIT).clamp(1, MAX_LIMIT);
 
     let mut walk = repo.revwalk().map_err(to_app_err)?;
     // Topological keeps parents-after-children; time breaks ties by commit date

--- a/src-tauri/src/git_log.rs
+++ b/src-tauri/src/git_log.rs
@@ -393,10 +393,7 @@ pub async fn git_commit_files(repo_path: String, oid: String) -> Result<Vec<Comm
             .find_commit(Oid::from_str(&oid).map_err(|e| AppError::Other(e.to_string()))?)
             .map_err(|e| AppError::Other(format!("commit not found: {e}")))?;
         let tree = commit.tree().map_err(|e| AppError::Other(e.to_string()))?;
-        let parent_tree = commit
-            .parent(0)
-            .ok()
-            .and_then(|p| p.tree().ok());
+        let parent_tree = commit.parent(0).ok().and_then(|p| p.tree().ok());
         let diff = repo
             .diff_tree_to_tree(parent_tree.as_ref(), Some(&tree), None)
             .map_err(|e| AppError::Other(e.to_string()))?;
@@ -418,7 +415,10 @@ pub async fn git_commit_files(repo_path: String, oid: String) -> Result<Vec<Comm
                 .or_else(|| delta.old_file().path())
                 .map(|p| p.to_string_lossy().to_string())
                 .unwrap_or_default();
-            files.push(CommitFile { path, status: status.to_string() });
+            files.push(CommitFile {
+                path,
+                status: status.to_string(),
+            });
         }
         Ok(files)
     })
@@ -463,12 +463,16 @@ mod tests {
     fn commit(repo: &Repository, msg: &str, parents: &[Oid]) -> Oid {
         let sig = git2::Signature::now("Test User", "test@example.com").unwrap();
         let mut index = repo.index().unwrap();
-        index.add_all(["*"], git2::IndexAddOption::DEFAULT, None).unwrap();
+        index
+            .add_all(["*"], git2::IndexAddOption::DEFAULT, None)
+            .unwrap();
         index.write().unwrap();
         let tree_oid = index.write_tree().unwrap();
         let tree = repo.find_tree(tree_oid).unwrap();
-        let parent_commits: Vec<git2::Commit> =
-            parents.iter().map(|p| repo.find_commit(*p).unwrap()).collect();
+        let parent_commits: Vec<git2::Commit> = parents
+            .iter()
+            .map(|p| repo.find_commit(*p).unwrap())
+            .collect();
         let parent_refs: Vec<&git2::Commit> = parent_commits.iter().collect();
         repo.commit(Some("HEAD"), &sig, &sig, msg, &tree, &parent_refs)
             .unwrap()
@@ -595,18 +599,27 @@ mod tests {
         // Page 1: skip 0, limit 4.
         let page1 = build_log(
             &repo,
-            &GitLogOptions { skip: 0, limit: Some(4) },
+            &GitLogOptions {
+                skip: 0,
+                limit: Some(4),
+            },
             &no_cancel(),
         )
         .unwrap();
         assert_eq!(page1.commits.len(), 4);
         assert!(page1.has_more);
-        assert_eq!(page1.next_cursor.as_deref(), Some(page1.commits[3].oid.as_str()));
+        assert_eq!(
+            page1.next_cursor.as_deref(),
+            Some(page1.commits[3].oid.as_str())
+        );
 
         // Page 2: skip 4, limit 4.
         let page2 = build_log(
             &repo,
-            &GitLogOptions { skip: 4, limit: Some(4) },
+            &GitLogOptions {
+                skip: 4,
+                limit: Some(4),
+            },
             &no_cancel(),
         )
         .unwrap();
@@ -616,7 +629,10 @@ mod tests {
         // Page 3: skip 8, limit 4 → only 2 remain, no more pages.
         let page3 = build_log(
             &repo,
-            &GitLogOptions { skip: 8, limit: Some(4) },
+            &GitLogOptions {
+                skip: 8,
+                limit: Some(4),
+            },
             &no_cancel(),
         )
         .unwrap();
@@ -641,7 +657,10 @@ mod tests {
         let (_dir, repo, _oids) = linear_repo();
         let page = build_log(
             &repo,
-            &GitLogOptions { skip: 100, limit: Some(10) },
+            &GitLogOptions {
+                skip: 100,
+                limit: Some(10),
+            },
             &no_cancel(),
         )
         .unwrap();

--- a/src-tauri/src/terminal.rs
+++ b/src-tauri/src/terminal.rs
@@ -66,7 +66,9 @@ struct Osc7Scanner {
 
 impl Osc7Scanner {
     fn new() -> Self {
-        Self { carry: String::new() }
+        Self {
+            carry: String::new(),
+        }
     }
 
     /// Feed a decoded text chunk; returns any complete cwd paths found.
@@ -306,7 +308,9 @@ fn zsh_shim_files() -> [(&'static str, String); 4] {
 /// failure degrades gracefully to spawning without cwd reporting.
 #[cfg(unix)]
 fn install_zsh_shim(cmd: &mut CommandBuilder) {
-    let Some(cache) = dirs::cache_dir() else { return };
+    let Some(cache) = dirs::cache_dir() else {
+        return;
+    };
     let shim = cache.join("tauri-explorer").join("zsh-shim");
     // Recreate fresh each spawn so a stale/edited shim can't linger.
     let _ = std::fs::remove_dir_all(&shim);
@@ -409,16 +413,16 @@ fn spawn_shell(
         .lock()
         .map_err(|e| AppError::Other(format!("terminals registry lock poisoned: {e}")))?
         .insert(
-        id,
-        TerminalHandle {
-            writer,
-            master: pair.master,
-            killer,
-            window_label,
-            pid,
-            shell_cwd: None,
-        },
-    );
+            id,
+            TerminalHandle {
+                writer,
+                master: pair.master,
+                killer,
+                window_label,
+                pid,
+                shell_cwd: None,
+            },
+        );
 
     std::thread::spawn(move || {
         let mut buf = [0u8; 8192];
@@ -436,8 +440,10 @@ fn spawn_shell(
                         for cwd in scanner.push(&text) {
                             // Reader thread (returns ()): recover the registry
                             // rather than panic if another holder poisoned it.
-                            if let Some(h) =
-                                terminals().lock().unwrap_or_else(|e| e.into_inner()).get_mut(&id)
+                            if let Some(h) = terminals()
+                                .lock()
+                                .unwrap_or_else(|e| e.into_inner())
+                                .get_mut(&id)
                             {
                                 h.shell_cwd = Some(cwd.clone());
                             }
@@ -449,7 +455,10 @@ fn spawn_shell(
             }
         }
         let code = child.wait().ok().map(|status| status.exit_code());
-        terminals().lock().unwrap_or_else(|e| e.into_inner()).remove(&id);
+        terminals()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .remove(&id);
         on_exit(code);
     });
 
@@ -681,7 +690,10 @@ mod tests {
             if let Ok(chunk) = rx.recv_timeout(Duration::from_millis(100)) {
                 output.push_str(&chunk);
             }
-            assert!(std::time::Instant::now() < deadline, "shell never exited; output: {output}");
+            assert!(
+                std::time::Instant::now() < deadline,
+                "shell never exited; output: {output}"
+            );
         };
         while let Ok(chunk) = rx.try_recv() {
             output.push_str(&chunk);
@@ -693,7 +705,10 @@ mod tests {
         );
         assert!(exited.is_some(), "exit code should be reported");
         assert!(
-            !terminals().lock().unwrap_or_else(|e| e.into_inner()).contains_key(&id),
+            !terminals()
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .contains_key(&id),
             "registry entry should be removed after exit"
         );
     }
@@ -885,14 +900,29 @@ mod tests {
 
         for (name, body) in &files {
             // Each shim sources the user's equivalent and restores the shim dir.
-            assert!(body.contains(&format!("$USER_ZDOTDIR/{name}")), "{name} sources user file");
-            assert!(body.contains("_TE_SHIM_ZDOTDIR"), "{name} restores shim dir");
+            assert!(
+                body.contains(&format!("$USER_ZDOTDIR/{name}")),
+                "{name} sources user file"
+            );
+            assert!(
+                body.contains("_TE_SHIM_ZDOTDIR"),
+                "{name} restores shim dir"
+            );
         }
 
         let zshrc = &files[2].1;
-        assert!(zshrc.contains("_tauri_explorer_osc7"), "zshrc adds the OSC 7 hook");
-        assert!(zshrc.contains("add-zsh-hook chpwd"), "zshrc registers a chpwd hook");
-        assert!(zshrc.contains("file://"), "zshrc emits an OSC 7 file:// sequence");
+        assert!(
+            zshrc.contains("_tauri_explorer_osc7"),
+            "zshrc adds the OSC 7 hook"
+        );
+        assert!(
+            zshrc.contains("add-zsh-hook chpwd"),
+            "zshrc registers a chpwd hook"
+        );
+        assert!(
+            zshrc.contains("file://"),
+            "zshrc emits an OSC 7 file:// sequence"
+        );
     }
 
     // ─── busy detection ──────────────────────────────────────────────────────
@@ -904,9 +934,17 @@ mod tests {
     #[cfg(unix)]
     fn busy_detection_tracks_foreground_command() {
         let (exit_tx, _exit_rx) = mpsc::channel::<Option<u32>>();
-        let id = spawn_shell("busy-test".into(), None, 80, 24, |_| {}, move |c| {
-            let _ = exit_tx.send(c);
-        }, |_| {})
+        let id = spawn_shell(
+            "busy-test".into(),
+            None,
+            80,
+            24,
+            |_| {},
+            move |c| {
+                let _ = exit_tx.send(c);
+            },
+            |_| {},
+        )
         .expect("spawn failed");
 
         let busy_now = || {
@@ -917,14 +955,21 @@ mod tests {
         // Let the shell reach its prompt.
         let idle_deadline = std::time::Instant::now() + Duration::from_secs(5);
         while busy_now() {
-            assert!(std::time::Instant::now() < idle_deadline, "shell never became idle");
+            assert!(
+                std::time::Instant::now() < idle_deadline,
+                "shell never became idle"
+            );
             std::thread::sleep(Duration::from_millis(50));
         }
 
         // Start a foreground command.
         {
             let mut map = terminals().lock().unwrap_or_else(|e| e.into_inner());
-            map.get_mut(&id).unwrap().writer.write_all(b"sleep 2\n").unwrap();
+            map.get_mut(&id)
+                .unwrap()
+                .writer
+                .write_all(b"sleep 2\n")
+                .unwrap();
         }
 
         // Poll until busy is observed.
@@ -933,18 +978,28 @@ mod tests {
             if busy_now() {
                 break;
             }
-            assert!(std::time::Instant::now() < busy_deadline, "sleep never registered as busy");
+            assert!(
+                std::time::Instant::now() < busy_deadline,
+                "sleep never registered as busy"
+            );
             std::thread::sleep(Duration::from_millis(20));
         }
 
         // …and idle again after it finishes.
         let done_deadline = std::time::Instant::now() + Duration::from_secs(6);
         while busy_now() {
-            assert!(std::time::Instant::now() < done_deadline, "shell stayed busy after sleep");
+            assert!(
+                std::time::Instant::now() < done_deadline,
+                "shell stayed busy after sleep"
+            );
             std::thread::sleep(Duration::from_millis(50));
         }
 
-        terminals().lock().unwrap_or_else(|e| e.into_inner()).get_mut(&id).map(|h| h.killer.kill());
+        terminals()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .get_mut(&id)
+            .map(|h| h.killer.kill());
     }
 
     /// If `zsh` is installed, spawning through `spawn_shell` should produce an
@@ -998,7 +1053,11 @@ mod tests {
         while let Ok(chunk) = rx.try_recv() {
             output.push_str(&chunk);
         }
-        terminals().lock().unwrap_or_else(|e| e.into_inner()).get_mut(&id).map(|h| h.killer.kill());
+        terminals()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .get_mut(&id)
+            .map(|h| h.killer.kill());
 
         assert!(
             got_cwd.is_ok(),

--- a/src-tauri/src/thumbnails.rs
+++ b/src-tauri/src/thumbnails.rs
@@ -654,7 +654,11 @@ fn set_ffmpeg_path_impl(path: Option<String>) {
 
 fn resolve_ffmpeg_path() -> Option<PathBuf> {
     // 1. Explicit user-configured path wins.
-    if let Some(p) = ffmpeg_override().lock().unwrap_or_else(|e| e.into_inner()).clone() {
+    if let Some(p) = ffmpeg_override()
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .clone()
+    {
         let pb = PathBuf::from(&p);
         if ffmpeg_runs(&pb) {
             log::info!(
@@ -1088,16 +1092,27 @@ mod tests {
     #[test]
     fn folder_preview_selects_sorted_capped_images() {
         let dir = tempdir().unwrap();
-        for name in ["zebra.png", "beta.jpg", "alpha.webp", "delta.gif", "notes.txt"] {
+        for name in [
+            "zebra.png",
+            "beta.jpg",
+            "alpha.webp",
+            "delta.gif",
+            "notes.txt",
+        ] {
             touch(dir.path(), name);
         }
 
-        let preview =
-            get_folder_preview_sync(dir.path().to_string_lossy().to_string()).unwrap();
+        let preview = get_folder_preview_sync(dir.path().to_string_lossy().to_string()).unwrap();
         let names: Vec<_> = preview
             .image_paths
             .iter()
-            .map(|p| Path::new(p).file_name().unwrap().to_string_lossy().to_string())
+            .map(|p| {
+                Path::new(p)
+                    .file_name()
+                    .unwrap()
+                    .to_string_lossy()
+                    .to_string()
+            })
             .collect();
         // Byte-sorted, capped at FOLDER_PREVIEW_MAX_IMAGES, non-images excluded.
         assert_eq!(names, vec!["alpha.webp", "beta.jpg", "delta.gif"]);
@@ -1110,8 +1125,7 @@ mod tests {
             touch(dir.path(), name);
         }
 
-        let preview =
-            get_folder_preview_sync(dir.path().to_string_lossy().to_string()).unwrap();
+        let preview = get_folder_preview_sync(dir.path().to_string_lossy().to_string()).unwrap();
         assert_eq!(preview.image_paths.len(), 1);
         assert!(preview.image_paths[0].ends_with("visible.png"));
     }
@@ -1121,8 +1135,7 @@ mod tests {
         let dir = tempdir().unwrap();
         touch(dir.path(), "notes.txt");
 
-        let preview =
-            get_folder_preview_sync(dir.path().to_string_lossy().to_string()).unwrap();
+        let preview = get_folder_preview_sync(dir.path().to_string_lossy().to_string()).unwrap();
         assert!(preview.image_paths.is_empty());
         assert!(!preview.fingerprint.is_empty());
 
@@ -1135,19 +1148,16 @@ mod tests {
     fn folder_preview_fingerprint_changes_when_image_set_changes() {
         let dir = tempdir().unwrap();
         touch(dir.path(), "a.png");
-        let before =
-            get_folder_preview_sync(dir.path().to_string_lossy().to_string()).unwrap();
+        let before = get_folder_preview_sync(dir.path().to_string_lossy().to_string()).unwrap();
 
         touch(dir.path(), "b.png");
-        let after =
-            get_folder_preview_sync(dir.path().to_string_lossy().to_string()).unwrap();
+        let after = get_folder_preview_sync(dir.path().to_string_lossy().to_string()).unwrap();
 
         assert_ne!(before.fingerprint, after.fingerprint);
         assert_eq!(after.image_paths.len(), 2);
 
         // Unchanged folder ⇒ stable fingerprint (the short-circuit contract).
-        let again =
-            get_folder_preview_sync(dir.path().to_string_lossy().to_string()).unwrap();
+        let again = get_folder_preview_sync(dir.path().to_string_lossy().to_string()).unwrap();
         assert_eq!(after.fingerprint, again.fingerprint);
     }
 

--- a/src-tauri/src/warm_pool.rs
+++ b/src-tauri/src/warm_pool.rs
@@ -115,13 +115,17 @@ static POOL: Mutex<PoolState> = Mutex::new(PoolState {
 /// already at target size — the caller must not create a warm window then.
 #[tauri::command]
 pub async fn warm_pool_begin_spawn() -> bool {
-    POOL.lock().unwrap_or_else(|e| e.into_inner()).try_reserve_spawn(Instant::now())
+    POOL.lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .try_reserve_spawn(Instant::now())
 }
 
 /// Release a reservation after a failed spawn (webview creation error).
 #[tauri::command]
 pub async fn warm_pool_cancel_spawn() {
-    POOL.lock().unwrap_or_else(|e| e.into_inner()).release_spawn();
+    POOL.lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .release_spawn();
 }
 
 /// Called by the warm window itself once its activate-listener is registered.
@@ -162,7 +166,9 @@ pub async fn warm_pool_claim(app: AppHandle) -> Option<String> {
 /// would linger hidden while counting as real — keeping the app alive forever.
 #[tauri::command]
 pub async fn warm_pool_discard(app: AppHandle, label: String) {
-    POOL.lock().unwrap_or_else(|e| e.into_inner()).forget(&label);
+    POOL.lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .forget(&label);
     if let Some(window) = app.get_webview_window(&label) {
         let _ = window.destroy();
     }


### PR DESCRIPTION
Post-release CI hygiene, so main's checks run green:
- cargo fmt sweep + clippy fixes (is_multiple_of, clamp, unused import) from the session's Rust commits (#171)
- perf-check script points at vitest.perf.config.ts — it had been running zero benchmarks since the perf-suite isolation (#170)
- CLAUDE.md rule: delegated agent worktrees must merge origin/dev before working (#166)

dev CI is green on this exact state (run 28703411499).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AXT4p9YaYuCn7YBxuaV4b3