### PR TITLE
docs: per-issue lessons files — stop the every-merge rebase churn (#544)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ Rules that bite:
 
 - **Start at [docs/code-map/](docs/code-map/)**: [map-feature.md](docs/code-map/map-feature.md) for cross-layer work and bug hunts, [map-playbook.md](docs/code-map/map-playbook.md) recipes for task-shaped changes (new palette command / context-menu action / Tauri command / setting), [map-folder.md](docs/code-map/map-folder.md) as the exhaustive per-file index. For a small localized change you can already name, skip the maps and grep (measured net loss on cheap tasks; prose architecture docs were deleted for the same reason — see [STUDY.md](docs/code-map/STUDY.md)).
 - **Keep the maps current or they turn harmful.** New/moved source file → update `map-folder.md` (+ the `map-feature.md` cluster), then `python3 docs/code-map/validate.py --coverage`. CI runs the same check.
-- [docs/lessons_learnt.md](docs/lessons_learnt.md) — gotchas from closed issues; append to it when you fix a bug, search it when you hunt one.
+- [docs/lessons/](docs/lessons/) — gotchas from closed issues, **one file per issue**: write `docs/lessons/<issue>-<slug>.md` when you fix a bug (never append to the frozen [docs/lessons_learnt.md](docs/lessons_learnt.md) archive — shared-file appends conflicted every open PR, #544). When hunting a bug, search both: `grep -ri <term> docs/lessons/ docs/lessons_learnt.md`.
 
 ## Issues, Branches, Screenshots
 
@@ -78,8 +78,8 @@ Anything whose failure mode involves races, watcher timing, git state, or cache 
 - Agent-tool worktrees are created from **main**, not `dev`: a delegated agent must start by branching from `origin/dev` (or the coordinator's integration branch), and the coordinator verifies `git merge-base` before merging.
 - Agents work **only inside their worktree cwd with relative paths**. Absolute paths leak edits into the main checkout — it has happened; coordinators should spot-check `git -C <main-repo> status` while agents run.
 - Port :1420 belongs to the main session. Agents needing a dev server or E2E run use their own port with a throwaway config.
-- Squash-merge conflicts in `lessons_learnt.md` / `map-feature.md` are usually both-append — resolve as a union, checking for line-level supersedes.
+- Squash-merge conflicts in `map-feature.md` are usually both-append — resolve as a union, checking for line-level supersedes. (`lessons_learnt.md` is frozen; lessons are per-issue files now, which cannot conflict.)
 
 ## Debugging
 
-When a bug resists quick diagnosis: search `lessons_learnt.md` and commit history first, then add targeted logging/instrumentation before another fix attempt. Suite-wide test timeouts (~5 s) under parallel/CPU load are a known flake mode — rerun the failing files in isolation before treating them as regressions.
+When a bug resists quick diagnosis: search `docs/lessons/` + the frozen `lessons_learnt.md` archive and commit history first, then add targeted logging/instrumentation before another fix attempt. Suite-wide test timeouts (~5 s) under parallel/CPU load are a known flake mode — rerun the failing files in isolation before treating them as regressions.

--- a/docs/lessons/README.md
+++ b/docs/lessons/README.md
@@ -1,0 +1,23 @@
+# Lessons — one file per issue
+
+Gotchas, non-obvious behaviors, and key takeaways from closed issues. One file
+per issue, named `<issue>-<slug>.md` (e.g. `544-per-issue-lessons.md`), written
+on the branch that fixes the issue.
+
+**Why per-issue files:** every branch used to append to the shared
+[`../lessons_learnt.md`](../lessons_learnt.md), so every merge to `dev`
+conflicted every open PR at end-of-file — each landing forced a rebase, a
+re-review, and a full CI re-run on every other branch (#544). Distinct files
+cannot conflict. `merge=union` was considered and rejected: GitHub's
+mergeability check ignores merge drivers.
+
+Conventions:
+
+- **Write** `docs/lessons/<issue>-<slug>.md` when you fix a bug or learn
+  something non-obvious. Same content style as the archive: what bit you, why,
+  and the rule that prevents it next time. A few lines is plenty; skip the file
+  entirely if the issue taught nothing non-obvious.
+- **Search** with `grep -ri <term> docs/lessons/ docs/lessons_learnt.md` — the
+  old shared file is FROZEN as an archive (still searchable, never appended).
+- No index file to update — the directory listing is the index (an index file
+  would just recreate the shared-append conflict).

--- a/docs/lessons_learnt.md
+++ b/docs/lessons_learnt.md
@@ -1,6 +1,9 @@
-# Lessons Learnt
+# Lessons Learnt (FROZEN archive — do not append)
 
-Gotchas, non-obvious behaviors, and key takeaways from closed issues.
+Gotchas, non-obvious behaviors, and key takeaways from closed issues, up to
+2026-07-27. **New lessons go in [`lessons/<issue>-<slug>.md`](lessons/) — one
+file per issue** (#544: shared-file appends conflicted every open PR on every
+merge). Keep searching this file; it stays as the archive.
 
 ---
 


### PR DESCRIPTION
## Summary
Freezes `docs/lessons_learnt.md` as a searchable archive and moves new lessons to **one file per issue** (`docs/lessons/<issue>-<slug>.md`, convention in `docs/lessons/README.md`). Every merge to `dev` was conflicting every open PR on the shared file's end-of-file append, forcing a rebase + re-review + full CI re-run per landing.

**Deliberately descoped:** per-area code-map fragments. Map conflicts are distant-hunk (only same-section adds collide), the path-overlap serializer already keeps same-area PRs from running concurrently, and `validate.py`'s coverage guard is built around a single `map-folder.md`. Split later only if map conflicts recur in practice.

## Acceptance Criteria
- [ ] `docs/lessons/README.md` documents the per-issue convention and search recipe
- [ ] `lessons_learnt.md` is headed as a frozen archive pointing at `docs/lessons/`
- [ ] `CLAUDE.md` no longer instructs appending to the shared file (write/search/debug references all updated)

## Screenshots
None required — docs-only, no user-visible effect.

Fixes #544

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RZv5eXsQVMUiFv53Gn9HUm