### PR TITLE
perf: skip per-entry git probes on slow mounts

### DIFF
--- a/docs/lessons/480-slow-mount-git-repo-probes.md
+++ b/docs/lessons/480-slow-mount-git-repo-probes.md
@@ -1,0 +1,8 @@
+# Issue 480: Keep optional Git folder decoration off slow listings
+
+`FileEntry.is_git_repo` is an icon-decoration hint, not information needed to
+list a directory. Checking each child for `.git` adds one stat per directory;
+on UNC network shares and WSL's 9P mount that becomes one remote round-trip per
+child. Directory listing therefore keeps the field for IPC compatibility but
+sets it to `false` without probing on UNC roots. Local listings continue to
+detect normal `.git` directories and worktree gitlink files.

--- a/src-tauri/src/files/dir_listing.rs
+++ b/src-tauri/src/files/dir_listing.rs
@@ -455,6 +455,34 @@ mod tests {
         );
     }
 
+    /// UNC roots cover both Windows network shares and WSL's 9P share. A
+    /// directory listing must not add one `.git` stat per child there (#480).
+    #[test]
+    fn git_repo_detection_policy_skips_unc_listing_roots() {
+        assert!(should_probe_git_repos(&PathBuf::from("C:\\Users\\me\\repos")));
+        assert!(!should_probe_git_repos(&PathBuf::from(
+            r"\\server\share\large-directory"
+        )));
+        assert!(!should_probe_git_repos(&PathBuf::from(
+            r"\\wsl.localhost\Ubuntu\home\me\large-directory"
+        )));
+    }
+
+    /// The listing seam returns a compatible `false` flag without touching a
+    /// child `.git` path when its root uses the slow-mount policy (#480).
+    #[test]
+    fn slow_mount_scan_does_not_detect_child_git_repositories() {
+        let dir = tempdir().unwrap();
+        fs::create_dir(dir.path().join("repo")) .unwrap();
+        fs::create_dir(dir.path().join("repo/.git")).unwrap();
+
+        let entries = scan_directory_parallel_with_git_repo_probe(&dir.path().to_path_buf(), false);
+        assert!(
+            !entries.iter().find(|entry| entry.name == "repo").unwrap().is_git_repo,
+            "slow-mount listings must leave is_git_repo false rather than stat each child .git"
+        );
+    }
+
     /// Contract test mirroring `tests/contract/fs-ops.contract.test.ts`
     /// (mock side). Both build the `listing_order` scenario from the shared
     /// fixture and assert the same ordering contract: directories first, then

--- a/src-tauri/src/files/dir_listing.rs
+++ b/src-tauri/src/files/dir_listing.rs
@@ -200,7 +200,7 @@ static LISTINGS: crate::task_registry::TaskRegistry = crate::task_registry::Task
 // pub: exercised directly by the `scan_directory_parallel` criterion bench
 // (src-tauri/benches/scan_directory_parallel.rs).
 pub fn scan_directory_parallel(dir_path: &PathBuf) -> Vec<FileEntry> {
-    scan_directory_parallel_with_git_repo_probe(dir_path, should_probe_git_repos(dir_path))
+    scan_directory_parallel_for_listing(dir_path, dir_path)
 }
 
 /// Network and WSL UNC paths may turn each file stat into a remote round trip.
@@ -211,13 +211,11 @@ fn should_probe_git_repos(dir_path: &Path) -> bool {
     !(path.starts_with("\\\\") || path.starts_with("//"))
 }
 
-/// Scan with an explicit Git-repository probe policy. Kept separate from the
-/// public benchmark entry point so the slow-mount policy is testable without a
-/// live network share.
-fn scan_directory_parallel_with_git_repo_probe(
-    dir_path: &PathBuf,
-    probe_git_repos: bool,
-) -> Vec<FileEntry> {
+/// Scan a readable directory using the policy for its user-visible listing
+/// root. Keeping the root separate makes the UNC policy testable without a
+/// live network share while production passes the same path for both values.
+fn scan_directory_parallel_for_listing(dir_path: &PathBuf, listing_root: &Path) -> Vec<FileEntry> {
+    let probe_git_repos = should_probe_git_repos(listing_root);
     use rayon::prelude::*;
 
     // jwalk parallelizes readdir, but the per-entry symlink_metadata stat would
@@ -495,12 +493,15 @@ mod tests {
     /// The listing seam returns a compatible `false` flag without touching a
     /// child `.git` path when its root uses the slow-mount policy (#480).
     #[test]
-    fn slow_mount_scan_does_not_detect_child_git_repositories() {
+    fn unc_listing_root_skips_child_git_repo_detection() {
         let dir = tempdir().unwrap();
         fs::create_dir(dir.path().join("repo")).unwrap();
         fs::create_dir(dir.path().join("repo/.git")).unwrap();
 
-        let entries = scan_directory_parallel_with_git_repo_probe(&dir.path().to_path_buf(), false);
+        let entries = scan_directory_parallel_for_listing(
+            &dir.path().to_path_buf(),
+            Path::new(r"\\server\share\large-directory"),
+        );
         assert!(
             !entries
                 .iter()

--- a/src-tauri/src/files/dir_listing.rs
+++ b/src-tauri/src/files/dir_listing.rs
@@ -10,7 +10,7 @@ use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Instant;
 use tauri::{AppHandle, Emitter};
 
-use super::{metadata_to_entry, DirectoryListing, FileEntry, FileKind};
+use super::{metadata_to_entry_with_git_repo_probe, DirectoryListing, FileEntry, FileKind};
 use crate::error::AppError;
 
 // ===================
@@ -200,6 +200,24 @@ static LISTINGS: crate::task_registry::TaskRegistry = crate::task_registry::Task
 // pub: exercised directly by the `scan_directory_parallel` criterion bench
 // (src-tauri/benches/scan_directory_parallel.rs).
 pub fn scan_directory_parallel(dir_path: &PathBuf) -> Vec<FileEntry> {
+    scan_directory_parallel_with_git_repo_probe(dir_path, should_probe_git_repos(dir_path))
+}
+
+/// Network and WSL UNC paths may turn each file stat into a remote round trip.
+/// `is_git_repo` only decorates folder icons, so listings skip that optional
+/// per-entry probe there while preserving it for local directories.
+fn should_probe_git_repos(dir_path: &PathBuf) -> bool {
+    let path = dir_path.to_string_lossy();
+    !(path.starts_with("\\\\") || path.starts_with("//"))
+}
+
+/// Scan with an explicit Git-repository probe policy. Kept separate from the
+/// public benchmark entry point so the slow-mount policy is testable without a
+/// live network share.
+fn scan_directory_parallel_with_git_repo_probe(
+    dir_path: &PathBuf,
+    probe_git_repos: bool,
+) -> Vec<FileEntry> {
     use rayon::prelude::*;
 
     // jwalk parallelizes readdir, but the per-entry symlink_metadata stat would
@@ -224,7 +242,11 @@ pub fn scan_directory_parallel(dir_path: &PathBuf) -> Vec<FileEntry> {
         .into_par_iter()
         .filter_map(|path| {
             let metadata = fs::symlink_metadata(&path).ok()?;
-            Some(metadata_to_entry(&path, &metadata))
+            Some(metadata_to_entry_with_git_repo_probe(
+                &path,
+                &metadata,
+                probe_git_repos,
+            ))
         })
         .collect();
 
@@ -459,7 +481,9 @@ mod tests {
     /// directory listing must not add one `.git` stat per child there (#480).
     #[test]
     fn git_repo_detection_policy_skips_unc_listing_roots() {
-        assert!(should_probe_git_repos(&PathBuf::from("C:\\Users\\me\\repos")));
+        assert!(should_probe_git_repos(&PathBuf::from(
+            "C:\\Users\\me\\repos"
+        )));
         assert!(!should_probe_git_repos(&PathBuf::from(
             r"\\server\share\large-directory"
         )));
@@ -473,12 +497,16 @@ mod tests {
     #[test]
     fn slow_mount_scan_does_not_detect_child_git_repositories() {
         let dir = tempdir().unwrap();
-        fs::create_dir(dir.path().join("repo")) .unwrap();
+        fs::create_dir(dir.path().join("repo")).unwrap();
         fs::create_dir(dir.path().join("repo/.git")).unwrap();
 
         let entries = scan_directory_parallel_with_git_repo_probe(&dir.path().to_path_buf(), false);
         assert!(
-            !entries.iter().find(|entry| entry.name == "repo").unwrap().is_git_repo,
+            !entries
+                .iter()
+                .find(|entry| entry.name == "repo")
+                .unwrap()
+                .is_git_repo,
             "slow-mount listings must leave is_git_repo false rather than stat each child .git"
         );
     }

--- a/src-tauri/src/files/dir_listing.rs
+++ b/src-tauri/src/files/dir_listing.rs
@@ -490,18 +490,22 @@ mod tests {
         )));
     }
 
-    /// The listing seam returns a compatible `false` flag without touching a
-    /// child `.git` path when its root uses the slow-mount policy (#480).
+    /// On Unix, backslashes are ordinary filename characters, which lets this
+    /// exercise the public scan entry point with a synthetic UNC root instead
+    /// of depending on a live network share (#480).
+    #[cfg(not(windows))]
     #[test]
-    fn unc_listing_root_skips_child_git_repo_detection() {
-        let dir = tempdir().unwrap();
-        fs::create_dir(dir.path().join("repo")).unwrap();
-        fs::create_dir(dir.path().join("repo/.git")).unwrap();
+    fn unc_listing_path_skips_child_git_repo_detection() {
+        let listing_root = PathBuf::from(format!(
+            r"\\server\share\tauri-explorer-test-{}",
+            std::process::id()
+        ));
+        fs::create_dir(&listing_root).unwrap();
+        fs::create_dir(listing_root.join("repo")).unwrap();
+        fs::create_dir(listing_root.join("repo/.git")).unwrap();
 
-        let entries = scan_directory_parallel_for_listing(
-            &dir.path().to_path_buf(),
-            Path::new(r"\\server\share\large-directory"),
-        );
+        let entries = scan_directory_parallel(&listing_root);
+        fs::remove_dir_all(&listing_root).unwrap();
         assert!(
             !entries
                 .iter()

--- a/src-tauri/src/files/dir_listing.rs
+++ b/src-tauri/src/files/dir_listing.rs
@@ -4,7 +4,7 @@
 use serde::Serialize;
 use std::collections::HashMap;
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::Ordering;
 use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Instant;
@@ -206,7 +206,7 @@ pub fn scan_directory_parallel(dir_path: &PathBuf) -> Vec<FileEntry> {
 /// Network and WSL UNC paths may turn each file stat into a remote round trip.
 /// `is_git_repo` only decorates folder icons, so listings skip that optional
 /// per-entry probe there while preserving it for local directories.
-fn should_probe_git_repos(dir_path: &PathBuf) -> bool {
+fn should_probe_git_repos(dir_path: &Path) -> bool {
     let path = dir_path.to_string_lossy();
     !(path.starts_with("\\\\") || path.starts_with("//"))
 }

--- a/src-tauri/src/files/mod.rs
+++ b/src-tauri/src/files/mod.rs
@@ -77,6 +77,16 @@ pub struct DirectoryListing {
 /// `fs::metadata` (stat) only for actual symlinks to get the resolved target info.
 /// This avoids redundant syscalls for the common case (non-symlink entries).
 pub(crate) fn metadata_to_entry(path: &Path, sym_meta: &fs::Metadata) -> FileEntry {
+    metadata_to_entry_with_git_repo_probe(path, sym_meta, true)
+}
+
+/// Convert metadata to a file entry, optionally skipping the per-directory
+/// `.git` probe used only for folder-icon decoration.
+pub(crate) fn metadata_to_entry_with_git_repo_probe(
+    path: &Path,
+    sym_meta: &fs::Metadata,
+    probe_git_repo: bool,
+) -> FileEntry {
     let name = path
         .file_name()
         .map(|n| n.to_string_lossy().to_string())
@@ -106,12 +116,11 @@ pub(crate) fn metadata_to_entry(path: &Path, sym_meta: &fs::Metadata) -> FileEnt
         FileKind::File
     };
 
-    // One extra `exists()` stat per *directory* entry — not the `read_dir`
-    // per-subdirectory cost that `is_empty` deliberately avoids (see
-    // `fill_is_empty` below). `.git` is checked as either a directory (a
-    // normal repo) or a file (worktrees/submodules use a `.git` gitlink
-    // file), so both cases are detected. Never probed for file entries.
-    let is_git_repo = matches!(kind, FileKind::Directory) && path.join(".git").exists();
+    // `.git` is checked as either a directory (a normal repo) or a file
+    // (worktrees/submodules use a gitlink file). Listings on slow mounts skip
+    // this optional decoration probe to avoid a network round-trip per child.
+    let is_git_repo =
+        probe_git_repo && matches!(kind, FileKind::Directory) && path.join(".git").exists();
 
     let size = if effective.is_dir() {
         0


### PR DESCRIPTION
Fixes #480

## Acceptance Criteria

- [ ] Listing a directory on a detected slow mount returns directory entries without probing each entry for a `.git` directory, and their `is_git_repo` field is `false`.
- [ ] Listing a directory on a local mount continues to report `is_git_repo: true` for child directories that contain `.git`.
- [ ] The slow-mount behavior is covered by a real Rust backend regression test that fails when the per-entry Git-repository probe is restored.

## Test Plan

- `cd src-tauri && cargo test --lib`
- `cd src-tauri && cargo fmt --check`
- `cd src-tauri && cargo clippy --lib -- -D warnings`
- Reverted the implementation in a temporary worktree; the new regression test failed as expected.

UNC roots, including WSL 9P paths and Windows network shares, now skip the optional per-directory `.git` decoration stat during directory listings. Local listings retain normal-repository and gitlink detection.