### PR TITLE
fix: instrument preview and directory navigation failures

### DIFF
--- a/docs/code-map/map-folder.md
+++ b/docs/code-map/map-folder.md
@@ -145,6 +145,7 @@ Layout: frontend `src/lib/` (components / state / api / composables / domain / p
 ## src/lib/api/ — invoke() bridge to Rust. Thin IPC wrappers; grep here for Tauri command names.
 - `common.ts` — mock-aware `invoke`, error extraction, Result types. Base of every api call.
 - `files.ts` — all file-op IPC (list, create, rename, copy, move, delete, estimate). Hot.
+- `frontend-log.ts` — forwards diagnosable webview failures to the native rotating log.
 - `mock-invoke.ts` — fake filesystem data for browser/E2E (no Tauri). Open when E2E data wrong.
 - `search.ts` — fuzzy file search + content search IPC + streaming. Hot.
 - `git.ts` — git status decoration + SCM (stage/commit/diff) IPC.

--- a/docs/lessons/497-preview-navigation-diagnostics.md
+++ b/docs/lessons/497-preview-navigation-diagnostics.md
@@ -2,8 +2,10 @@
 
 Preview loading and directory navigation cross separate frontend and native IPC
 boundaries. Log failures at both sides with the requested path, operation,
-error, and elapsed time: frontend asset decoding failures only exist in the
-webview, while filesystem and streaming failures need the native rolling log.
+error, and elapsed time. Frontend-only failures must also be forwarded through
+`log_frontend_error` so they reach the native rolling log instead of being
+limited to webview devtools. Navigation request/outcome events use `info!`,
+the default application log level, while high-volume detail remains `debug!`.
 For streamed directories, record the listing ID and whether a stream ended by
 cancellation so an expected supersession is distinguishable from a dropped
 navigation.

--- a/docs/lessons/497-preview-navigation-diagnostics.md
+++ b/docs/lessons/497-preview-navigation-diagnostics.md
@@ -1,0 +1,9 @@
+# Preview and navigation diagnostics
+
+Preview loading and directory navigation cross separate frontend and native IPC
+boundaries. Log failures at both sides with the requested path, operation,
+error, and elapsed time: frontend asset decoding failures only exist in the
+webview, while filesystem and streaming failures need the native rolling log.
+For streamed directories, record the listing ID and whether a stream ended by
+cancellation so an expected supersession is distinguishable from a dropped
+navigation.

--- a/src-tauri/src/archive.rs
+++ b/src-tauri/src/archive.rs
@@ -538,9 +538,28 @@ pub struct ArchiveListing {
 /// `root_folder`. Directories sort first, then alphabetically.
 #[tauri::command]
 pub async fn list_archive_contents(archive_path: String) -> Result<ArchiveListing, AppError> {
-    tokio::task::spawn_blocking(move || list_archive_contents_sync(&archive_path))
+    let started_at = std::time::Instant::now();
+    let log_path = archive_path.clone();
+    let result = tokio::task::spawn_blocking(move || list_archive_contents_sync(&archive_path))
         .await
-        .map_err(|e| AppError::Other(format!("Task join error: {}", e)))?
+        .map_err(|e| AppError::Other(format!("Task join error: {}", e)))?;
+    match result {
+        Ok(listing) => {
+            log::debug!(
+                "preview list_archive_contents completed: path={log_path:?}, entries={}, elapsed={:?}",
+                listing.entries.len(),
+                started_at.elapsed()
+            );
+            Ok(listing)
+        }
+        Err(error) => {
+            log::warn!(
+                "preview list_archive_contents failed: path={log_path:?}, elapsed={:?}, error={error}",
+                started_at.elapsed()
+            );
+            Err(error)
+        }
+    }
 }
 
 /// One zip entry reduced to its path components + classification.

--- a/src-tauri/src/files/dir_listing.rs
+++ b/src-tauri/src/files/dir_listing.rs
@@ -116,11 +116,19 @@ pub async fn list_directory(path: String) -> Result<DirectoryListing, AppError> 
     // directories) purely to dim empty-folder icons. The frontend resolves
     // emptiness lazily for visible directories via `is_directory_empty` (#129);
     // Miller columns already do their own on-demand probing.
-    let entries =
-        Arc::new(super::run_blocking(move || Ok(scan_directory_parallel(&dir_path))).await?);
+    let (entries, scan_diagnostics) =
+        super::run_blocking(move || Ok(scan_directory_with_diagnostics(&dir_path))).await?;
+    let entries = Arc::new(entries);
 
     let elapsed = t_start.elapsed();
-    if elapsed.as_millis() > 100 {
+    if scan_diagnostics.error_count > 0 {
+        log::warn!(
+            "preview list_directory completed with scan errors: path={path:?}, entries={}, scan_errors={}, samples={:?}, elapsed={elapsed:?}",
+            entries.len(),
+            scan_diagnostics.error_count,
+            scan_diagnostics.samples,
+        );
+    } else if elapsed.as_millis() > 100 {
         log::warn!(
             "preview list_directory slow: path={path:?}, entries={}, elapsed={:?}",
             entries.len(),
@@ -207,6 +215,30 @@ static LISTINGS: crate::task_registry::TaskRegistry = crate::task_registry::Task
 // pub: exercised directly by the `scan_directory_parallel` criterion bench
 // (src-tauri/benches/scan_directory_parallel.rs).
 pub fn scan_directory_parallel(dir_path: &PathBuf) -> Vec<FileEntry> {
+    scan_directory_with_diagnostics(dir_path).0
+}
+
+const MAX_SCAN_ERROR_SAMPLES: usize = 3;
+
+#[derive(Default)]
+struct ScanDiagnostics {
+    error_count: usize,
+    samples: Vec<String>,
+}
+
+impl ScanDiagnostics {
+    fn record(&mut self, error: impl std::fmt::Display) {
+        self.error_count += 1;
+        if self.samples.len() < MAX_SCAN_ERROR_SAMPLES {
+            self.samples.push(error.to_string());
+        }
+    }
+}
+
+/// Scan a directory while retaining bounded details for entries that could not
+/// be read or statted. A partial listing remains usable, but callers can log
+/// why it may be incomplete instead of reporting a misleading clean success.
+fn scan_directory_with_diagnostics(dir_path: &PathBuf) -> (Vec<FileEntry>, ScanDiagnostics) {
     scan_directory_parallel_for_listing(dir_path, dir_path)
 }
 
@@ -221,33 +253,37 @@ fn should_probe_git_repos(dir_path: &Path) -> bool {
 /// Scan a readable directory using the policy for its user-visible listing
 /// root. Keeping the root separate makes the UNC policy testable without a
 /// live network share while production passes the same path for both values.
-fn scan_directory_parallel_for_listing(dir_path: &PathBuf, listing_root: &Path) -> Vec<FileEntry> {
+fn scan_directory_parallel_for_listing(
+    dir_path: &PathBuf,
+    listing_root: &Path,
+) -> (Vec<FileEntry>, ScanDiagnostics) {
     let probe_git_repos = should_probe_git_repos(listing_root);
     use rayon::prelude::*;
+    let mut diagnostics = ScanDiagnostics::default();
 
     // jwalk parallelizes readdir, but the per-entry symlink_metadata stat would
     // otherwise serialize on the consuming thread. Collect the child paths first,
     // then fan the stat + metadata_to_entry work out across rayon's thread pool so
     // a flat 10k-entry dir doesn't stat on a single core.
-    let paths: Vec<PathBuf> = jwalk::WalkDir::new(dir_path)
+    let mut paths: Vec<PathBuf> = Vec::new();
+    for result in jwalk::WalkDir::new(dir_path)
         .max_depth(1)
         .skip_hidden(false)
         .into_iter()
-        .filter_map(|result| {
-            let dir_entry = result.ok()?;
-            // Skip the root directory itself
-            if dir_entry.depth() == 0 {
-                return None;
-            }
-            Some(dir_entry.path())
-        })
-        .collect();
+    {
+        match result {
+            Ok(dir_entry) if dir_entry.depth() != 0 => paths.push(dir_entry.path()),
+            Ok(_) => {}
+            Err(error) => diagnostics.record(format!("walk error: {error}")),
+        }
+    }
 
-    let mut entries: Vec<FileEntry> = paths
+    let scanned: Vec<Result<FileEntry, String>> = paths
         .into_par_iter()
-        .filter_map(|path| {
-            let metadata = fs::symlink_metadata(&path).ok()?;
-            Some(metadata_to_entry_with_git_repo_probe(
+        .map(|path| {
+            let metadata = fs::symlink_metadata(&path)
+                .map_err(|error| format!("metadata error for {}: {error}", path.display()))?;
+            Ok(metadata_to_entry_with_git_repo_probe(
                 &path,
                 &metadata,
                 probe_git_repos,
@@ -255,8 +291,16 @@ fn scan_directory_parallel_for_listing(dir_path: &PathBuf, listing_root: &Path) 
         })
         .collect();
 
+    let mut entries = Vec::with_capacity(scanned.len());
+    for entry in scanned {
+        match entry {
+            Ok(entry) => entries.push(entry),
+            Err(error) => diagnostics.record(error),
+        }
+    }
+
     sort_entries(&mut entries);
-    entries
+    (entries, diagnostics)
 }
 
 /// Start streaming directory listing.
@@ -286,8 +330,8 @@ pub async fn start_streaming_directory(
 
     let t_scan_start = std::time::Instant::now();
     // jwalk + per-entry stat calls are blocking work; keep them off the async executor.
-    let mut all_entries =
-        super::run_blocking(move || Ok(scan_directory_parallel(&dir_path))).await?;
+    let (mut all_entries, scan_diagnostics) =
+        super::run_blocking(move || Ok(scan_directory_with_diagnostics(&dir_path))).await?;
     let t_scan_end = std::time::Instant::now();
 
     let total_count = all_entries.len();
@@ -303,6 +347,15 @@ pub async fn start_streaming_directory(
     // subdirectory, so a 10k-dir scan would pay 10k read_dirs. The frontend
     // resolves emptiness lazily for visible directories via `is_directory_empty`
     // (#129), so neither the first batch nor the streamed chunks probe it here.
+    if scan_diagnostics.error_count > 0 {
+        log::warn!(
+            "navigation start_streaming_directory completed with scan errors: path={path:?}, entries={total_count}, scan_errors={}, samples={:?}, elapsed={:?}",
+            scan_diagnostics.error_count,
+            scan_diagnostics.samples,
+            started_at.elapsed()
+        );
+    }
+
     if total_count <= batch_size {
         log::debug!(
             "navigation start_streaming_directory completed: path={path:?}, entries={total_count}, streaming=false, elapsed={:?}",
@@ -401,6 +454,18 @@ mod tests {
         assert_eq!(result.entries.len(), 2);
         assert!(matches!(result.entries[0].kind, FileKind::Directory));
         assert!(matches!(result.entries[1].kind, FileKind::File));
+    }
+
+    #[test]
+    fn scan_records_a_bounded_sample_when_the_listing_root_cannot_be_read() {
+        let missing = tempdir().unwrap().path().join("missing");
+
+        let (entries, diagnostics) = scan_directory_with_diagnostics(&missing);
+
+        assert!(entries.is_empty());
+        assert!(diagnostics.error_count >= 1);
+        assert!(!diagnostics.samples.is_empty());
+        assert!(diagnostics.samples.len() <= MAX_SCAN_ERROR_SAMPLES);
     }
 
     /// The parallel scan never pays the per-subdirectory is_empty probe (its

--- a/src-tauri/src/files/dir_listing.rs
+++ b/src-tauri/src/files/dir_listing.rs
@@ -76,6 +76,7 @@ pub async fn is_directory_empty(path: String, include_hidden: bool) -> Result<bo
 #[tauri::command]
 pub async fn list_directory(path: String) -> Result<DirectoryListing, AppError> {
     let t_start = std::time::Instant::now();
+    log::debug!("preview list_directory requested: path={path:?}");
 
     // Check cache first
     {
@@ -85,8 +86,8 @@ pub async fn list_directory(path: String) -> Result<DirectoryListing, AppError> 
         if let Some(cached) = cache.get(&path) {
             if cached.cached_at.elapsed().as_secs() < CACHE_TTL_SECS {
                 log::debug!(
-                    "list_directory: cache hit ({} entries)",
-                    cached.entries.len()
+                    "preview list_directory cache hit: path={path:?}, entries={}",
+                    cached.entries.len(),
                 );
                 return Ok(DirectoryListing {
                     path: path.clone(),
@@ -100,10 +101,12 @@ pub async fn list_directory(path: String) -> Result<DirectoryListing, AppError> 
     let dir_path = PathBuf::from(&path);
 
     if !dir_path.exists() {
+        log::warn!("preview list_directory failed: path={path:?}, error=not found");
         return Err(AppError::NotFound(path.clone()));
     }
 
     if !dir_path.is_dir() {
+        log::warn!("preview list_directory failed: path={path:?}, error=not a directory");
         return Err(AppError::InvalidPath(format!("Not a directory: {}", path)));
     }
 
@@ -119,12 +122,16 @@ pub async fn list_directory(path: String) -> Result<DirectoryListing, AppError> 
     let elapsed = t_start.elapsed();
     if elapsed.as_millis() > 100 {
         log::warn!(
-            "Slow directory listing: {} entries in {:?}",
+            "preview list_directory slow: path={path:?}, entries={}, elapsed={:?}",
             entries.len(),
             elapsed
         );
     } else {
-        log::debug!("list_directory: {} entries in {:?}", entries.len(), elapsed);
+        log::debug!(
+            "preview list_directory completed: path={path:?}, entries={}, elapsed={:?}",
+            entries.len(),
+            elapsed
+        );
     }
 
     // Update cache
@@ -260,14 +267,20 @@ pub async fn start_streaming_directory(
     app: AppHandle,
     path: String,
 ) -> Result<DirectoryListing, AppError> {
+    let started_at = Instant::now();
+    log::debug!("navigation start_streaming_directory requested: path={path:?}");
     let dir_path = PathBuf::from(&path);
     let batch_size = 100;
 
     if !dir_path.exists() {
+        log::warn!("navigation start_streaming_directory failed: path={path:?}, error=not found");
         return Err(AppError::NotFound(path));
     }
 
     if !dir_path.is_dir() {
+        log::warn!(
+            "navigation start_streaming_directory failed: path={path:?}, error=not a directory"
+        );
         return Err(AppError::InvalidPath(format!("Not a directory: {}", path)));
     }
 
@@ -291,6 +304,10 @@ pub async fn start_streaming_directory(
     // resolves emptiness lazily for visible directories via `is_directory_empty`
     // (#129), so neither the first batch nor the streamed chunks probe it here.
     if total_count <= batch_size {
+        log::debug!(
+            "navigation start_streaming_directory completed: path={path:?}, entries={total_count}, streaming=false, elapsed={:?}",
+            started_at.elapsed()
+        );
         return Ok(DirectoryListing {
             path,
             entries: Arc::new(all_entries),
@@ -306,13 +323,15 @@ pub async fn start_streaming_directory(
     let path_clone = path.clone();
     std::thread::spawn(move || {
         let mut offset = batch_size;
+        let mut was_cancelled = false;
 
         for chunk in remaining.chunks(batch_size) {
             if cancelled.load(Ordering::Relaxed) {
+                was_cancelled = true;
                 break;
             }
 
-            let _ = app.emit(
+            if let Err(error) = app.emit(
                 "directory-entries",
                 DirectoryEntriesEvent {
                     listing_id,
@@ -321,7 +340,11 @@ pub async fn start_streaming_directory(
                     done: offset + chunk.len() >= total_count,
                     total_count,
                 },
-            );
+            ) {
+                log::warn!(
+                    "navigation directory-entries emit failed: path={path_clone:?}, listing_id={listing_id}, error={error}"
+                );
+            }
 
             offset += chunk.len();
             // Brief pacing so batched emits don't flood the IPC channel. The
@@ -331,8 +354,17 @@ pub async fn start_streaming_directory(
             std::thread::sleep(std::time::Duration::from_millis(1));
         }
 
+        log::debug!(
+            "navigation directory listing stream ended: path={path_clone:?}, listing_id={listing_id}, emitted_entries={}, cancelled={was_cancelled}",
+            offset.saturating_sub(batch_size)
+        );
         LISTINGS.cleanup(listing_id);
     });
+
+    log::debug!(
+        "navigation start_streaming_directory completed: path={path:?}, entries={total_count}, listing_id={listing_id}, streaming=true, elapsed={:?}",
+        started_at.elapsed()
+    );
 
     Ok(DirectoryListing {
         path,
@@ -344,6 +376,7 @@ pub async fn start_streaming_directory(
 /// Cancel an active directory listing.
 #[tauri::command]
 pub async fn cancel_directory_listing(listing_id: u64) -> Result<(), AppError> {
+    log::debug!("navigation cancel_directory_listing requested: listing_id={listing_id}");
     LISTINGS.cancel(listing_id);
     Ok(())
 }

--- a/src-tauri/src/files/dir_listing.rs
+++ b/src-tauri/src/files/dir_listing.rs
@@ -76,7 +76,7 @@ pub async fn is_directory_empty(path: String, include_hidden: bool) -> Result<bo
 #[tauri::command]
 pub async fn list_directory(path: String) -> Result<DirectoryListing, AppError> {
     let t_start = std::time::Instant::now();
-    log::debug!("preview list_directory requested: path={path:?}");
+    log::debug!("directory list_directory requested: path={path:?}");
 
     // Check cache first
     {
@@ -86,7 +86,7 @@ pub async fn list_directory(path: String) -> Result<DirectoryListing, AppError> 
         if let Some(cached) = cache.get(&path) {
             if cached.cached_at.elapsed().as_secs() < CACHE_TTL_SECS {
                 log::debug!(
-                    "preview list_directory cache hit: path={path:?}, entries={}",
+                    "directory list_directory cache hit: path={path:?}, entries={}",
                     cached.entries.len(),
                 );
                 return Ok(DirectoryListing {
@@ -101,12 +101,12 @@ pub async fn list_directory(path: String) -> Result<DirectoryListing, AppError> 
     let dir_path = PathBuf::from(&path);
 
     if !dir_path.exists() {
-        log::warn!("preview list_directory failed: path={path:?}, error=not found");
+        log::warn!("directory list_directory failed: path={path:?}, error=not found");
         return Err(AppError::NotFound(path.clone()));
     }
 
     if !dir_path.is_dir() {
-        log::warn!("preview list_directory failed: path={path:?}, error=not a directory");
+        log::warn!("directory list_directory failed: path={path:?}, error=not a directory");
         return Err(AppError::InvalidPath(format!("Not a directory: {}", path)));
     }
 
@@ -123,20 +123,20 @@ pub async fn list_directory(path: String) -> Result<DirectoryListing, AppError> 
     let elapsed = t_start.elapsed();
     if scan_diagnostics.error_count > 0 {
         log::warn!(
-            "preview list_directory completed with scan errors: path={path:?}, entries={}, scan_errors={}, samples={:?}, elapsed={elapsed:?}",
+            "directory list_directory completed with scan errors: path={path:?}, entries={}, scan_errors={}, samples={:?}, elapsed={elapsed:?}",
             entries.len(),
             scan_diagnostics.error_count,
             scan_diagnostics.samples,
         );
     } else if elapsed.as_millis() > 100 {
         log::warn!(
-            "preview list_directory slow: path={path:?}, entries={}, elapsed={:?}",
+            "directory list_directory slow: path={path:?}, entries={}, elapsed={:?}",
             entries.len(),
             elapsed
         );
     } else {
         log::debug!(
-            "preview list_directory completed: path={path:?}, entries={}, elapsed={:?}",
+            "directory list_directory completed: path={path:?}, entries={}, elapsed={:?}",
             entries.len(),
             elapsed
         );
@@ -233,12 +233,24 @@ impl ScanDiagnostics {
             self.samples.push(error.to_string());
         }
     }
+
+    fn merge(&mut self, mut other: Self) {
+        self.error_count += other.error_count;
+        let capacity = MAX_SCAN_ERROR_SAMPLES.saturating_sub(self.samples.len());
+        let take = capacity.min(other.samples.len());
+        self.samples.extend(other.samples.drain(..take));
+    }
 }
 
 /// Scan a directory while retaining bounded details for entries that could not
 /// be read or statted. A partial listing remains usable, but callers can log
 /// why it may be incomplete instead of reporting a misleading clean success.
 fn scan_directory_with_diagnostics(dir_path: &PathBuf) -> (Vec<FileEntry>, ScanDiagnostics) {
+    if !dir_path.exists() {
+        let mut diagnostics = ScanDiagnostics::default();
+        diagnostics.record(format!("listing root not found: {}", dir_path.display()));
+        return (Vec::new(), diagnostics);
+    }
     scan_directory_parallel_for_listing(dir_path, dir_path)
 }
 
@@ -278,26 +290,33 @@ fn scan_directory_parallel_for_listing(
         }
     }
 
-    let scanned: Vec<Result<FileEntry, String>> = paths
+    let (mut entries, diagnostics) = paths
         .into_par_iter()
-        .map(|path| {
-            let metadata = fs::symlink_metadata(&path)
-                .map_err(|error| format!("metadata error for {}: {error}", path.display()))?;
-            Ok(metadata_to_entry_with_git_repo_probe(
-                &path,
-                &metadata,
-                probe_git_repos,
-            ))
-        })
-        .collect();
-
-    let mut entries = Vec::with_capacity(scanned.len());
-    for entry in scanned {
-        match entry {
-            Ok(entry) => entries.push(entry),
-            Err(error) => diagnostics.record(error),
-        }
-    }
+        .fold(
+            || (Vec::new(), ScanDiagnostics::default()),
+            |(mut entries, mut diagnostics), path| {
+                match fs::symlink_metadata(&path) {
+                    Ok(metadata) => entries.push(metadata_to_entry_with_git_repo_probe(
+                        &path,
+                        &metadata,
+                        probe_git_repos,
+                    )),
+                    Err(error) => {
+                        diagnostics
+                            .record(format!("metadata error for {}: {error}", path.display()));
+                    }
+                }
+                (entries, diagnostics)
+            },
+        )
+        .reduce(
+            || (Vec::new(), ScanDiagnostics::default()),
+            |(mut entries, mut diagnostics), (other_entries, other_diagnostics)| {
+                entries.extend(other_entries);
+                diagnostics.merge(other_diagnostics);
+                (entries, diagnostics)
+            },
+        );
 
     sort_entries(&mut entries);
     (entries, diagnostics)
@@ -312,7 +331,7 @@ pub async fn start_streaming_directory(
     path: String,
 ) -> Result<DirectoryListing, AppError> {
     let started_at = Instant::now();
-    log::debug!("navigation start_streaming_directory requested: path={path:?}");
+    log::info!("navigation start_streaming_directory requested: path={path:?}");
     let dir_path = PathBuf::from(&path);
     let batch_size = 100;
 
@@ -357,7 +376,7 @@ pub async fn start_streaming_directory(
     }
 
     if total_count <= batch_size {
-        log::debug!(
+        log::info!(
             "navigation start_streaming_directory completed: path={path:?}, entries={total_count}, streaming=false, elapsed={:?}",
             started_at.elapsed()
         );
@@ -407,14 +426,14 @@ pub async fn start_streaming_directory(
             std::thread::sleep(std::time::Duration::from_millis(1));
         }
 
-        log::debug!(
+        log::info!(
             "navigation directory listing stream ended: path={path_clone:?}, listing_id={listing_id}, emitted_entries={}, cancelled={was_cancelled}",
             offset.saturating_sub(batch_size)
         );
         LISTINGS.cleanup(listing_id);
     });
 
-    log::debug!(
+    log::info!(
         "navigation start_streaming_directory completed: path={path:?}, entries={total_count}, listing_id={listing_id}, streaming=true, elapsed={:?}",
         started_at.elapsed()
     );
@@ -429,7 +448,7 @@ pub async fn start_streaming_directory(
 /// Cancel an active directory listing.
 #[tauri::command]
 pub async fn cancel_directory_listing(listing_id: u64) -> Result<(), AppError> {
-    log::debug!("navigation cancel_directory_listing requested: listing_id={listing_id}");
+    log::info!("navigation cancel_directory_listing requested: listing_id={listing_id}");
     LISTINGS.cancel(listing_id);
     Ok(())
 }

--- a/src-tauri/src/files/file_ops.rs
+++ b/src-tauri/src/files/file_ops.rs
@@ -664,7 +664,25 @@ fn perform_move(
 /// Read a text file's contents with a size limit (default 1MB).
 #[tauri::command]
 pub async fn read_text_file(path: String, max_bytes: Option<u64>) -> Result<String, AppError> {
-    run_blocking(move || read_text_file_impl(path, max_bytes)).await
+    let started_at = std::time::Instant::now();
+    let log_path = path.clone();
+    match run_blocking(move || read_text_file_impl(path, max_bytes)).await {
+        Ok(content) => {
+            log::debug!(
+                "preview read_text_file completed: path={log_path:?}, bytes={}, elapsed={:?}",
+                content.len(),
+                started_at.elapsed()
+            );
+            Ok(content)
+        }
+        Err(error) => {
+            log::warn!(
+                "preview read_text_file failed: path={log_path:?}, max_bytes={max_bytes:?}, elapsed={:?}, error={error}",
+                started_at.elapsed()
+            );
+            Err(error)
+        }
+    }
 }
 
 fn read_text_file_impl(path: String, max_bytes: Option<u64>) -> Result<String, AppError> {
@@ -728,7 +746,25 @@ fn read_text_file_impl(path: String, max_bytes: Option<u64>) -> Result<String, A
 /// 32 MB) so we don't base64 an enormous file into memory.
 #[tauri::command]
 pub async fn read_image_data_url(path: String, max_bytes: Option<u64>) -> Result<String, AppError> {
-    run_blocking(move || read_image_data_url_impl(path, max_bytes)).await
+    let started_at = std::time::Instant::now();
+    let log_path = path.clone();
+    match run_blocking(move || read_image_data_url_impl(path, max_bytes)).await {
+        Ok(data_url) => {
+            log::debug!(
+                "preview read_image_data_url completed: path={log_path:?}, data_url_bytes={}, elapsed={:?}",
+                data_url.len(),
+                started_at.elapsed()
+            );
+            Ok(data_url)
+        }
+        Err(error) => {
+            log::warn!(
+                "preview read_image_data_url failed: path={log_path:?}, max_bytes={max_bytes:?}, elapsed={:?}, error={error}",
+                started_at.elapsed()
+            );
+            Err(error)
+        }
+    }
 }
 
 fn read_image_data_url_impl(path: String, max_bytes: Option<u64>) -> Result<String, AppError> {

--- a/src/lib/api/files.ts
+++ b/src/lib/api/files.ts
@@ -470,6 +470,7 @@ export async function startStreamingDirectory(
   path: string
 ): Promise<ApiResult<DirectoryListing>> {
   const startedAt = Date.now();
+  console.debug("[navigation] start_streaming_directory requested", { path });
   // Virtual paths never stream: the provider returns the full listing inline
   // (listing_id null), which the caller treats as a non-streaming result.
   const provider = providerFor(path);

--- a/src/lib/api/files.ts
+++ b/src/lib/api/files.ts
@@ -16,6 +16,7 @@ import {
   type ApiResult,
 } from "./common";
 import { providerFor } from "$lib/plugins/fs-providers";
+import { logFrontendDiagnostic } from "./frontend-log";
 
 /**
  * Fetch directory listing from Tauri backend.
@@ -307,6 +308,12 @@ export async function readTextFile(path: string, maxBytes?: number): Promise<Api
       error,
       elapsedMs: Date.now() - startedAt,
     });
+    logFrontendDiagnostic("preview read_text_file failed", {
+      path,
+      maxBytes: maxBytes ?? null,
+      error,
+      elapsedMs: Date.now() - startedAt,
+    });
     return { ok: false, error };
   }
 }
@@ -343,6 +350,12 @@ export async function readImageAsBlobUrl(
   } catch (err) {
     const error = extractError(err);
     console.warn("[preview] read_image_data_url failed", {
+      path,
+      maxBytes: maxBytes ?? null,
+      error,
+      elapsedMs: Date.now() - startedAt,
+    });
+    logFrontendDiagnostic("preview read_image_data_url failed", {
       path,
       maxBytes: maxBytes ?? null,
       error,
@@ -490,6 +503,11 @@ export async function startStreamingDirectory(
         error,
         elapsedMs: Date.now() - startedAt,
       });
+      logFrontendDiagnostic("navigation virtual directory listing failed", {
+        path,
+        error,
+        elapsedMs: Date.now() - startedAt,
+      });
       return { ok: false, error };
     }
   }
@@ -505,6 +523,11 @@ export async function startStreamingDirectory(
   } catch (err) {
     const error = extractError(err);
     console.warn("[navigation] start_streaming_directory failed", {
+      path,
+      error,
+      elapsedMs: Date.now() - startedAt,
+    });
+    logFrontendDiagnostic("navigation start_streaming_directory failed", {
       path,
       error,
       elapsedMs: Date.now() - startedAt,

--- a/src/lib/api/files.ts
+++ b/src/lib/api/files.ts
@@ -289,11 +289,25 @@ export async function writeTextFile(path: string, content: string): Promise<ApiR
 export async function readTextFile(path: string, maxBytes?: number): Promise<ApiResult<string>> {
   const guard = virtualPathGuard(path);
   if (guard) return guard;
+  const startedAt = Date.now();
   try {
     const content = await invoke<string>("read_text_file", { path, maxBytes: maxBytes ?? null });
+    console.debug("[preview] read_text_file completed", {
+      path,
+      maxBytes: maxBytes ?? null,
+      bytes: content.length,
+      elapsedMs: Date.now() - startedAt,
+    });
     return { ok: true, data: content };
   } catch (err) {
-    return { ok: false, error: extractError(err) };
+    const error = extractError(err);
+    console.warn("[preview] read_text_file failed", {
+      path,
+      maxBytes: maxBytes ?? null,
+      error,
+      elapsedMs: Date.now() - startedAt,
+    });
+    return { ok: false, error };
   }
 }
 
@@ -313,14 +327,28 @@ export async function readImageAsBlobUrl(
   path: string,
   maxBytes?: number
 ): Promise<ApiResult<string>> {
+  const startedAt = Date.now();
   try {
     const dataUri = await invoke<string>("read_image_data_url", {
       path,
       maxBytes: maxBytes ?? null,
     });
+    console.debug("[preview] read_image_data_url completed", {
+      path,
+      maxBytes: maxBytes ?? null,
+      dataUriBytes: dataUri.length,
+      elapsedMs: Date.now() - startedAt,
+    });
     return { ok: true, data: dataUriToBlobUrl(dataUri) };
   } catch (err) {
-    return { ok: false, error: extractError(err) };
+    const error = extractError(err);
+    console.warn("[preview] read_image_data_url failed", {
+      path,
+      maxBytes: maxBytes ?? null,
+      error,
+      elapsedMs: Date.now() - startedAt,
+    });
+    return { ok: false, error };
   }
 }
 
@@ -441,22 +469,46 @@ export interface DirectoryEntriesEvent {
 export async function startStreamingDirectory(
   path: string
 ): Promise<ApiResult<DirectoryListing>> {
+  const startedAt = Date.now();
   // Virtual paths never stream: the provider returns the full listing inline
   // (listing_id null), which the caller treats as a non-streaming result.
   const provider = providerFor(path);
   if (provider) {
     try {
       const data = await provider.list(path);
+      console.debug("[navigation] virtual directory listing completed", {
+        path,
+        entries: data.entries.length,
+        elapsedMs: Date.now() - startedAt,
+      });
       return { ok: true, data: { ...data, listing_id: null } };
     } catch (err) {
-      return { ok: false, error: extractError(err) };
+      const error = extractError(err);
+      console.warn("[navigation] virtual directory listing failed", {
+        path,
+        error,
+        elapsedMs: Date.now() - startedAt,
+      });
+      return { ok: false, error };
     }
   }
   try {
     const data = await invoke<DirectoryListing>("start_streaming_directory", { path });
+    console.debug("[navigation] start_streaming_directory completed", {
+      path,
+      listingId: data.listing_id,
+      entries: data.entries.length,
+      elapsedMs: Date.now() - startedAt,
+    });
     return { ok: true, data };
   } catch (err) {
-    return { ok: false, error: extractError(err) };
+    const error = extractError(err);
+    console.warn("[navigation] start_streaming_directory failed", {
+      path,
+      error,
+      elapsedMs: Date.now() - startedAt,
+    });
+    return { ok: false, error };
   }
 }
 

--- a/src/lib/api/frontend-log.ts
+++ b/src/lib/api/frontend-log.ts
@@ -1,0 +1,13 @@
+/**
+ * Forward a diagnosable webview failure into the native rotating application
+ * log. Console output alone is unavailable to users of production builds.
+ */
+import { invoke } from "./common";
+
+export function logFrontendDiagnostic(
+  event: string,
+  context: Record<string, string | number | boolean | null>,
+): void {
+  const message = `[${event}] ${JSON.stringify(context)}`;
+  void invoke<void>("log_frontend_error", { message }).catch(() => undefined);
+}

--- a/src/lib/components/PreviewPane.svelte
+++ b/src/lib/components/PreviewPane.svelte
@@ -622,7 +622,8 @@
         try {
           const { convertFileSrc } = await import("@tauri-apps/api/core");
           previewPdfUrl = `${convertFileSrc(file.path)}?v=${bust}`;
-        } catch {
+        } catch (error) {
+          console.warn("[preview] PDF asset URL creation failed", { path: file.path, error });
           previewError = "Cannot preview PDF";
         }
       } else {
@@ -646,10 +647,12 @@
             await decodeImage(fallback.data);
             if (file.path !== lastPreviewPath) return; // Stale after decode
             previewImageUrl = fallback.data;
-          } catch {
+          } catch (error) {
+            console.warn("[preview] backend image decode failed", { path: file.path, error });
             previewError = "Cannot preview image";
           }
         } else {
+          console.warn("[preview] backend image read failed", { path: file.path, error: fallback.error });
           previewError = "Cannot preview image";
         }
       };
@@ -664,7 +667,10 @@
           if (file.path !== lastPreviewPath) return; // Stale after decode
           previewImageUrl = url;
         } catch (assetErr) {
-          console.warn("asset:// image preview failed, falling back to backend read:", assetErr);
+          console.warn("[preview] asset image decode failed; using backend fallback", {
+            path: file.path,
+            error: assetErr,
+          });
           await loadViaBackend();
         }
       } else {

--- a/src/lib/components/PreviewPane.svelte
+++ b/src/lib/components/PreviewPane.svelte
@@ -16,6 +16,7 @@
   import { getFileIconColor } from "$lib/domain/file-types";
   import { getScmStore } from "$lib/state/scm.svelte";
   import { gitCommitFileDiff } from "$lib/api/git-log";
+  import { logFrontendDiagnostic } from "$lib/api/frontend-log";
 
   // Window-global surface: the preview's SCM diff follows the ACTIVE pane's
   // store (#334) — reactive through windowTabsManager.activePaneId.
@@ -624,6 +625,10 @@
           previewPdfUrl = `${convertFileSrc(file.path)}?v=${bust}`;
         } catch (error) {
           console.warn("[preview] PDF asset URL creation failed", { path: file.path, error });
+          logFrontendDiagnostic("preview PDF asset URL creation failed", {
+            path: file.path,
+            error: error instanceof Error ? error.message : String(error),
+          });
           previewError = "Cannot preview PDF";
         }
       } else {
@@ -649,10 +654,18 @@
             previewImageUrl = fallback.data;
           } catch (error) {
             console.warn("[preview] backend image decode failed", { path: file.path, error });
+            logFrontendDiagnostic("preview backend image decode failed", {
+              path: file.path,
+              error: error instanceof Error ? error.message : String(error),
+            });
             previewError = "Cannot preview image";
           }
         } else {
           console.warn("[preview] backend image read failed", { path: file.path, error: fallback.error });
+          logFrontendDiagnostic("preview backend image read failed", {
+            path: file.path,
+            error: fallback.error,
+          });
           previewError = "Cannot preview image";
         }
       };
@@ -670,6 +683,10 @@
           console.warn("[preview] asset image decode failed; using backend fallback", {
             path: file.path,
             error: assetErr,
+          });
+          logFrontendDiagnostic("preview asset image decode failed", {
+            path: file.path,
+            error: assetErr instanceof Error ? assetErr.message : String(assetErr),
           });
           await loadViaBackend();
         }

--- a/tests/api/files-instrumentation.test.ts
+++ b/tests/api/files-instrumentation.test.ts
@@ -92,6 +92,10 @@ describe("preview and directory IPC instrumentation (#497)", () => {
       "[navigation] start_streaming_directory completed",
       expect.objectContaining({ path: "/tmp/folder", listingId: null, entries: 0 }),
     );
+    expect(debug).toHaveBeenCalledWith(
+      "[navigation] start_streaming_directory requested",
+      { path: "/tmp/folder" },
+    );
     debug.mockRestore();
   });
 });

--- a/tests/api/files-instrumentation.test.ts
+++ b/tests/api/files-instrumentation.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { invokeMock } = vi.hoisted(() => ({
+  invokeMock: vi.fn(),
+}));
+
+vi.mock("$lib/api/common", () => ({
+  invoke: invokeMock,
+  extractError: (error: unknown) => error instanceof Error ? error.message : String(error),
+  virtualPathGuard: () => null,
+  dataUriToBlobUrl: () => "blob:preview",
+}));
+
+vi.mock("$lib/plugins/fs-providers", () => ({ providerFor: () => undefined }));
+
+import { readImageAsBlobUrl, readTextFile, startStreamingDirectory } from "$lib/api/files";
+
+describe("preview and directory IPC instrumentation (#497)", () => {
+  beforeEach(() => {
+    invokeMock.mockReset();
+  });
+
+  it("records a failed text preview request with its path and backend error", async () => {
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    invokeMock.mockRejectedValueOnce(new Error("WSL file unavailable"));
+
+    await expect(readTextFile("\\\\wsl.localhost\\Ubuntu\\home\\me\\note.md", 512)).resolves.toEqual({
+      ok: false,
+      error: "WSL file unavailable",
+    });
+
+    expect(warning).toHaveBeenCalledWith(
+      "[preview] read_text_file failed",
+      expect.objectContaining({
+        path: "\\\\wsl.localhost\\Ubuntu\\home\\me\\note.md",
+        maxBytes: 512,
+        error: "WSL file unavailable",
+      }),
+    );
+    warning.mockRestore();
+  });
+
+  it("records a failed image fallback request with its path and backend error", async () => {
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    invokeMock.mockRejectedValueOnce(new Error("cloud file is offline"));
+
+    await expect(readImageAsBlobUrl("C:\\Users\\me\\OneDrive\\photo.jpg")).resolves.toEqual({
+      ok: false,
+      error: "cloud file is offline",
+    });
+
+    expect(warning).toHaveBeenCalledWith(
+      "[preview] read_image_data_url failed",
+      expect.objectContaining({
+        path: "C:\\Users\\me\\OneDrive\\photo.jpg",
+        error: "cloud file is offline",
+      }),
+    );
+    warning.mockRestore();
+  });
+
+  it("records a failed directory navigation IPC request with its path and error", async () => {
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    invokeMock.mockRejectedValueOnce(new Error("permission denied"));
+
+    await expect(startStreamingDirectory("/mnt/wsl/project")).resolves.toEqual({
+      ok: false,
+      error: "permission denied",
+    });
+
+    expect(warning).toHaveBeenCalledWith(
+      "[navigation] start_streaming_directory failed",
+      expect.objectContaining({ path: "/mnt/wsl/project", error: "permission denied" }),
+    );
+    warning.mockRestore();
+  });
+});

--- a/tests/api/files-instrumentation.test.ts
+++ b/tests/api/files-instrumentation.test.ts
@@ -74,4 +74,24 @@ describe("preview and directory IPC instrumentation (#497)", () => {
     );
     warning.mockRestore();
   });
+
+  it("records completed preview and directory requests with their paths and outcomes", async () => {
+    const debug = vi.spyOn(console, "debug").mockImplementation(() => undefined);
+    invokeMock
+      .mockResolvedValueOnce("preview text")
+      .mockResolvedValueOnce({ path: "/tmp/folder", entries: [], listing_id: null });
+
+    await expect(readTextFile("/tmp/note.md")).resolves.toEqual({ ok: true, data: "preview text" });
+    await expect(startStreamingDirectory("/tmp/folder")).resolves.toMatchObject({ ok: true });
+
+    expect(debug).toHaveBeenCalledWith(
+      "[preview] read_text_file completed",
+      expect.objectContaining({ path: "/tmp/note.md", bytes: 12 }),
+    );
+    expect(debug).toHaveBeenCalledWith(
+      "[navigation] start_streaming_directory completed",
+      expect.objectContaining({ path: "/tmp/folder", listingId: null, entries: 0 }),
+    );
+    debug.mockRestore();
+  });
 });

--- a/tests/api/files-instrumentation.test.ts
+++ b/tests/api/files-instrumentation.test.ts
@@ -18,6 +18,7 @@ import { readImageAsBlobUrl, readTextFile, startStreamingDirectory } from "$lib/
 describe("preview and directory IPC instrumentation (#497)", () => {
   beforeEach(() => {
     invokeMock.mockReset();
+    invokeMock.mockResolvedValue(undefined);
   });
 
   it("records a failed text preview request with its path and backend error", async () => {
@@ -36,6 +37,10 @@ describe("preview and directory IPC instrumentation (#497)", () => {
         maxBytes: 512,
         error: "WSL file unavailable",
       }),
+    );
+    expect(invokeMock).toHaveBeenCalledWith(
+      "log_frontend_error",
+      expect.objectContaining({ message: expect.stringContaining("preview read_text_file failed") }),
     );
     warning.mockRestore();
   });
@@ -56,6 +61,10 @@ describe("preview and directory IPC instrumentation (#497)", () => {
         error: "cloud file is offline",
       }),
     );
+    expect(invokeMock).toHaveBeenCalledWith(
+      "log_frontend_error",
+      expect.objectContaining({ message: expect.stringContaining("preview read_image_data_url failed") }),
+    );
     warning.mockRestore();
   });
 
@@ -71,6 +80,10 @@ describe("preview and directory IPC instrumentation (#497)", () => {
     expect(warning).toHaveBeenCalledWith(
       "[navigation] start_streaming_directory failed",
       expect.objectContaining({ path: "/mnt/wsl/project", error: "permission denied" }),
+    );
+    expect(invokeMock).toHaveBeenCalledWith(
+      "log_frontend_error",
+      expect.objectContaining({ message: expect.stringContaining("navigation start_streaming_directory failed") }),
     );
     warning.mockRestore();
   });

--- a/tests/api/frontend-log.test.ts
+++ b/tests/api/frontend-log.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it, vi } from "vitest";
+
+const { invokeMock } = vi.hoisted(() => ({ invokeMock: vi.fn() }));
+
+vi.mock("$lib/api/common", () => ({ invoke: invokeMock }));
+
+import { logFrontendDiagnostic } from "$lib/api/frontend-log";
+
+describe("frontend diagnostic logging", () => {
+  it("forwards a frontend-only preview failure to the native rolling-log command", () => {
+    invokeMock.mockResolvedValue(undefined);
+    logFrontendDiagnostic("preview asset image decode failed", {
+      path: "C:\\Users\\me\\photo.jpg",
+      error: "image decode failed",
+    });
+
+    expect(invokeMock).toHaveBeenCalledWith("log_frontend_error", {
+      message: '[preview asset image decode failed] {"path":"C:\\\\Users\\\\me\\\\photo.jpg","error":"image decode failed"}',
+    });
+  });
+});


### PR DESCRIPTION
Fixes #497

## Acceptance Criteria
- [ ] When preview loading fails, the application log records the attempted path, preview type, and error context.
- [ ] When a directory-change IPC request is attempted, succeeds, or fails, the application log records the requested path and outcome so a silent navigation failure can be diagnosed.

## Implementation
- Routes frontend-only PDF/image preview diagnostics through the native rotating log.
- Emits native navigation request, outcome, stream, and cancellation events at the default `info` level.
- Preserves bounded filesystem scan errors in directory diagnostics without an extra serial result-draining pass.
- No screenshots: logging/instrumentation only; no user-visible UI change.

## Verification
- `bunx vitest run` — 1547 passing
- `cd src-tauri && cargo test --quiet` — 333 passing, 6 ignored
- `bun run check`
- `cd src-tauri && cargo bench --bench scan_directory_parallel -- --noplot` — 5.55 ms mean for 10k files (baseline 5.75 ms)