### PR TITLE
test: guard virtualization windowing in all views

### DIFF
--- a/e2e/virtualization-windowing.spec.ts
+++ b/e2e/virtualization-windowing.spec.ts
@@ -1,0 +1,35 @@
+/**
+ * Regression: every file-list mode must keep huge directories DOM-virtualized.
+ *
+ * This asserts a browser layout outcome, not a component implementation detail:
+ * the visible DOM remains bounded and VirtualList owns vertical scrolling. A
+ * missing `min-height: 0` on any view wrapper makes that wrapper expand to the
+ * list's full content height, which causes VirtualList to render every row.
+ */
+import { test, expect } from "./fixtures";
+import { ALL_VIEW_MODES } from "./helpers";
+
+const HUGE = "/perf/huge";
+
+test.skip(({ browserName }) => browserName !== "chromium", "layout outcome; chromium is the calibrated engine");
+
+for (const mode of ALL_VIEW_MODES) {
+  test(`${mode} view windows a huge directory and its viewport scrolls (#479)`, async ({ page }) => {
+    await page.goto(`/?path=${HUGE}&viewMode=${mode}`);
+
+    const viewport = page.locator(`.${mode}-view .virtual-viewport`);
+    await viewport.waitFor({ timeout: 10000 });
+    await viewport.locator(".virtual-item").first().waitFor({ timeout: 10000 });
+
+    const stats = await viewport.evaluate((element) => ({
+      renderedRows: element.querySelectorAll(".virtual-item").length,
+      viewportIsScroller: element.scrollHeight > element.clientHeight + 2,
+    }));
+
+    // `/perf/huge` contains 5,000 entries. A generous cap proves browser-level
+    // windowing without tying the assertion to a specific viewport height.
+    expect(stats.renderedRows).toBeGreaterThan(0);
+    expect(stats.renderedRows).toBeLessThan(200);
+    expect(stats.viewportIsScroller).toBe(true);
+  });
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -9,18 +9,20 @@ export default defineConfig({
   reporter: "html",
   use: {
     baseURL: "http://localhost:1420",
-    // Nix hosts can supply their wrapped browser when Playwright's downloaded
-    // Chromium cannot load the host's shared libraries. CI leaves this unset.
-    launchOptions: process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH
-      ? { executablePath: process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH }
-      : undefined,
     trace: "on-first-retry",
     screenshot: "only-on-failure",
   },
   projects: [
     {
       name: "chromium",
-      use: { ...devices["Desktop Chrome"] },
+      // Nix hosts can supply their wrapped browser when Playwright's downloaded
+      // Chromium cannot load the host's shared libraries. CI leaves this unset.
+      use: {
+        ...devices["Desktop Chrome"],
+        launchOptions: process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH
+          ? { executablePath: process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH }
+          : undefined,
+      },
     },
     // WebKit ≈ WKWebView: the closest automated proxy for the macOS webview
     // (no WKWebView WebDriver exists). Opt-in: WEBKIT=1 locally, or

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -9,6 +9,11 @@ export default defineConfig({
   reporter: "html",
   use: {
     baseURL: "http://localhost:1420",
+    // Nix hosts can supply their wrapped browser when Playwright's downloaded
+    // Chromium cannot load the host's shared libraries. CI leaves this unset.
+    launchOptions: process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH
+      ? { executablePath: process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH }
+      : undefined,
     trace: "on-first-retry",
     screenshot: "only-on-failure",
   },

--- a/src/lib/components/ListView.svelte
+++ b/src/lib/components/ListView.svelte
@@ -93,6 +93,7 @@
     display: flex;
     flex-direction: column;
     flex: 1;
+    min-height: 0;
   }
 
   /* Each virtualized row is an equal-width grid. minmax(0, 1fr), not 1fr: a

--- a/src/lib/components/ListView.svelte
+++ b/src/lib/components/ListView.svelte
@@ -93,7 +93,6 @@
     display: flex;
     flex-direction: column;
     flex: 1;
-    min-height: 0;
   }
 
   /* Each virtualized row is an equal-width grid. minmax(0, 1fr), not 1fr: a


### PR DESCRIPTION
## Summary

Adds a Chromium e2e regression guard for DOM virtualization in Details, List, and Tiles when the browser opens the mock-backed 5,000-entry directory.

## Acceptance Criteria

- [ ] With `ALL_VIEW_MODES=1`, opening `/perf/huge` in each of Details, List, and Tiles leaves fewer than 200 `.virtual-item` elements in the rendered browser DOM.
- [ ] In each of those views, `.virtual-viewport` has overflow content and is the vertical scroller.

## Test Plan

- `bun run check`
- `ALL_VIEW_MODES=1 npx playwright test e2e/virtualization-windowing.spec.ts`
- `WEBKIT=1 PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=<local-chromium> npx playwright test e2e/virtualization-windowing.spec.ts --project=webkit --list`
- TDD evidence: removing `min-height: 0` from ListView caused only the List variant to time out waiting for its bounded virtual viewport; restoring it produced three passing variants.

## Review Notes

- The spec asserts browser-observable layout outcomes at the VirtualList seam. Its assertions cover DOM row count and viewport scrolling, and the red/green commits demonstrate that it fails when the List flex wrapper loses its layout guard.
- Review repair: the local Chromium executable override is now nested under the Chromium project’s `use` configuration, so an opt-in WebKit project never receives that Chromium executable path.

Fixes #479