### PR TITLE
fix: document FileChooser portal enablement

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,10 @@ The public report relay under `website/api/` uses `GITHUB_ISSUE_TOKEN` only for 
 
 **E2E tests assert outcomes**, not existence — a QuickOpen test verifies results appear for a query, not that the modal opened.
 
+The Linux FileChooser portal is selected through the user's
+`~/.config/xdg-desktop-portal/portals.conf`; do not add deprecated `UseIn`
+desktop matching to `packaging/tauri-explorer.portal`.
+
 SCM archive actions preserve each repo-relative path under `.archive/` and add
 `.archive` to `.gitignore`; this keeps archived files out of the Untracked list.
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,22 @@ git clone https://github.com/xnmp/tauri-explorer && cd tauri-explorer/packaging/
 
 Binaries aren't code-signed yet. Windows shows a SmartScreen warning on first launch. macOS reports un-notarized downloads as "damaged" and blocks them — the `xattr` command above clears the quarantine flag (Homebrew removed its `--no-quarantine` option, so this manual step is the only way until the app is notarized).
 
+## Use as system file picker
+
+On Linux, Tauri Explorer provides an `xdg-desktop-portal` FileChooser backend.
+Portal backends are selected by your desktop portal configuration; installing the
+package alone does not replace an existing GTK or desktop-specific file picker.
+
+To select Tauri Explorer for file-picker requests, create
+`~/.config/xdg-desktop-portal/portals.conf` with:
+
+```ini
+[preferred]
+org.freedesktop.impl.portal.FileChooser=tauri-explorer
+```
+
+Restart `xdg-desktop-portal` or sign out and back in after changing the file.
+
 ## Building
 
 Requires [Rust](https://rustup.rs/), [Bun](https://bun.sh/), and [Tauri v2 prerequisites](https://v2.tauri.app/start/prerequisites/).

--- a/docs/lessons/564-filechooser-portal-enable.md
+++ b/docs/lessons/564-filechooser-portal-enable.md
@@ -1,0 +1,6 @@
+# FileChooser portal enablement
+
+`xdg-desktop-portal` does not select a FileChooser backend merely because its
+portal descriptor is installed. Users must set the preferred backend in
+`~/.config/xdg-desktop-portal/portals.conf`; do not rely on the deprecated
+`UseIn` mechanism for selection.

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -5,6 +5,7 @@ pkgname=tauri-explorer-bin
 pkgver=1.5.0
 pkgrel=1
 pkgdesc="A keyboard-first file manager: fuzzy quick-open, ripgrep content search, a command palette for every action"
+install=tauri-explorer-bin.install
 arch=('x86_64')
 url="https://github.com/xnmp/tauri-explorer"
 license=('MIT')

--- a/packaging/aur/tauri-explorer-bin.install
+++ b/packaging/aur/tauri-explorer-bin.install
@@ -4,7 +4,8 @@ tauri-explorer provides an xdg-desktop-portal FileChooser backend.
 To use it as your system file picker, configure:
   ~/.config/xdg-desktop-portal/portals.conf
 with:
-  org.freedesktop.impl.portal.FileChooser=tauri-explorer
+[preferred]
+org.freedesktop.impl.portal.FileChooser=tauri-explorer
 
 See the setup instructions in README.md:
   https://github.com/xnmp/tauri-explorer/blob/main/README.md#use-as-system-file-picker

--- a/packaging/aur/tauri-explorer-bin.install
+++ b/packaging/aur/tauri-explorer-bin.install
@@ -1,0 +1,16 @@
+post_install() {
+  cat <<'EOF'
+tauri-explorer provides an xdg-desktop-portal FileChooser backend.
+To use it as your system file picker, configure:
+  ~/.config/xdg-desktop-portal/portals.conf
+with:
+  org.freedesktop.impl.portal.FileChooser=tauri-explorer
+
+See the setup instructions in README.md:
+  https://github.com/xnmp/tauri-explorer/blob/main/README.md#use-as-system-file-picker
+EOF
+}
+
+post_upgrade() {
+  post_install
+}

--- a/tests/portal-filechooser-documentation.test.ts
+++ b/tests/portal-filechooser-documentation.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, it } from "vitest";
 
 const readRepositoryFile = (path: string) =>
   readFileSync(new URL(`../${path}`, import.meta.url), "utf8");
+const portalSelectionConfig =
+  "[preferred]\norg.freedesktop.impl.portal.FileChooser=tauri-explorer";
 
 describe("FileChooser portal enablement documentation", () => {
   it("publishes the configuration that selects Tauri Explorer as the system file picker", () => {
@@ -10,9 +12,7 @@ describe("FileChooser portal enablement documentation", () => {
 
     expect(readme).toContain("## Use as system file picker");
     expect(readme).toContain("~/.config/xdg-desktop-portal/portals.conf");
-    expect(readme).toContain(
-      "org.freedesktop.impl.portal.FileChooser=tauri-explorer",
-    );
+    expect(readme).toContain(portalSelectionConfig);
   });
 
   it("shows Arch package users the same setup after installation", () => {
@@ -23,9 +23,7 @@ describe("FileChooser portal enablement documentation", () => {
 
     expect(pkgbuild).toContain("install=tauri-explorer-bin.install");
     expect(postInstall).toContain("portals.conf");
-    expect(postInstall).toContain(
-      "org.freedesktop.impl.portal.FileChooser=tauri-explorer",
-    );
+    expect(postInstall).toContain(portalSelectionConfig);
     expect(postInstall).toContain("README.md");
   });
 });

--- a/tests/portal-filechooser-documentation.test.ts
+++ b/tests/portal-filechooser-documentation.test.ts
@@ -1,0 +1,31 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const readRepositoryFile = (path: string) =>
+  readFileSync(new URL(`../${path}`, import.meta.url), "utf8");
+
+describe("FileChooser portal enablement documentation", () => {
+  it("publishes the configuration that selects Tauri Explorer as the system file picker", () => {
+    const readme = readRepositoryFile("README.md");
+
+    expect(readme).toContain("## Use as system file picker");
+    expect(readme).toContain("~/.config/xdg-desktop-portal/portals.conf");
+    expect(readme).toContain(
+      "org.freedesktop.impl.portal.FileChooser=tauri-explorer",
+    );
+  });
+
+  it("shows Arch package users the same setup after installation", () => {
+    const pkgbuild = readRepositoryFile("packaging/aur/PKGBUILD");
+    const postInstall = readRepositoryFile(
+      "packaging/aur/tauri-explorer-bin.install",
+    );
+
+    expect(pkgbuild).toContain("install=tauri-explorer-bin.install");
+    expect(postInstall).toContain("portals.conf");
+    expect(postInstall).toContain(
+      "org.freedesktop.impl.portal.FileChooser=tauri-explorer",
+    );
+    expect(postInstall).toContain("README.md");
+  });
+});


### PR DESCRIPTION
## Summary

- document the supported `portals.conf` selection required for the Linux FileChooser portal
- show the complete `[preferred]` configuration after AUR binary-package installation
- add a regression test for the complete published setup instructions

## Acceptance Criteria

- [ ] README gives Linux users a copyable `~/.config/xdg-desktop-portal/portals.conf` configuration that selects tauri-explorer for the FileChooser portal.
- [ ] The packaged AUR installation tells users after installation where to find the FileChooser enablement configuration.
- [ ] The documented portal-selection configuration is covered by an automated test that fails if the actual published instruction is removed or changed.

## Test Plan

- `bunx vitest run tests/portal-filechooser-documentation.test.ts`
- `bun run test` (all 1,562 standard and 30 performance tests passed in the prior verification; the repair rerun encountered the repository's known Vitest RPC teardown flake, while its isolated file passed)
- `bash -n packaging/aur/PKGBUILD packaging/aur/tauri-explorer-bin.install`

## Review

Adversarial pre-PR review: PASS.

Review repair: added the missing contiguous `[preferred]` section to the AUR post-install example and strengthened the regression test to require the complete configuration in both README and package messaging. Scoped verifier: PASS; no repair-induced regressions found.

Fixes #564