### PR TITLE
fix: enumerate Linux removable drives from mount table

### DIFF
--- a/docs/lessons/546-linux-mount-table-drive-enumeration.md
+++ b/docs/lessons/546-linux-mount-table-drive-enumeration.md
@@ -1,0 +1,8 @@
+# Linux mount-table drive enumeration (#546)
+
+Linux removable media cannot be discovered reliably by scanning conventional
+mount directories: desktop launch environments may omit `USER`, and valid
+mounts may live anywhere. Read `/proc/self/mountinfo`, decode its escaped mount
+paths, and resolve each `/dev` partition back to its parent `/sys/block` device
+to read the kernel's `removable` flag. Keep pseudo filesystems out of the drive
+list and use `/dev/disk/by-label` when udev provides a volume label.

--- a/docs/lessons/546-linux-mount-table-drive-enumeration.md
+++ b/docs/lessons/546-linux-mount-table-drive-enumeration.md
@@ -5,4 +5,7 @@ mount directories: desktop launch environments may omit `USER`, and valid
 mounts may live anywhere. Read `/proc/self/mountinfo`, decode its escaped mount
 paths, and resolve each `/dev` partition back to its parent `/sys/block` device
 to read the kernel's `removable` flag. Keep pseudo filesystems out of the drive
-list and use `/dev/disk/by-label` when udev provides a volume label.
+list, exclude operating-system roots such as separately mounted `/boot` and
+`/home`, and use `/dev/disk/by-label` when udev provides a volume label. Keep
+the complete production enumeration path injectable so mount/unmount behavior
+is testable without host mounts or environment variables.

--- a/docs/lessons/546-linux-mount-table-drive-enumeration.md
+++ b/docs/lessons/546-linux-mount-table-drive-enumeration.md
@@ -5,7 +5,7 @@ mount directories: desktop launch environments may omit `USER`, and valid
 mounts may live anywhere. Read `/proc/self/mountinfo`, decode its escaped mount
 paths, and resolve each `/dev` partition back to its parent `/sys/block` device
 to read the kernel's `removable` flag. Keep pseudo filesystems out of the drive
-list, exclude operating-system roots such as separately mounted `/boot` and
+list, exclude operating-system roots and submounts such as `/boot/efi` and
 `/home`, and use `/dev/disk/by-label` when udev provides a volume label. Keep
 the complete production enumeration path injectable so mount/unmount behavior
 is testable without host mounts or environment variables.

--- a/src-tauri/src/files/drives.rs
+++ b/src-tauri/src/files/drives.rs
@@ -672,12 +672,12 @@ mod linux_tests {
     #[test]
     fn exposes_removable_mounts_from_any_mount_path_without_user_environment() {
         let sys_block = tempfile::tempdir().expect("temporary sysfs block directory");
-        let disk = sys_block.path().join("sdb");
-        std::fs::create_dir_all(disk.join("sdb1")).expect("partition directory");
+        let disk = sys_block.path().join("tauriusb546");
+        std::fs::create_dir_all(disk.join("tauriusb546p1")).expect("partition directory");
         std::fs::write(disk.join("removable"), "1\n").expect("removable flag");
 
         let drives = parse_linux_block_mounts(
-            "42 35 8:17 / /mnt/USB\\040BACKUP rw,relatime - ext4 /dev/sdb1 rw\n",
+            "42 35 8:17 / /mnt/USB\\040BACKUP rw,relatime - ext4 /dev/tauriusb546p1 rw\n",
             sys_block.path(),
         );
 
@@ -707,16 +707,16 @@ mod linux_tests {
     #[test]
     fn resolves_partition_to_its_backing_disk_removable_flag() {
         let sys_block = tempfile::tempdir().expect("temporary sysfs block directory");
-        let disk = sys_block.path().join("mmcblk0");
-        std::fs::create_dir_all(disk.join("mmcblk0p1")).expect("partition directory");
+        let disk = sys_block.path().join("taurimmedia546");
+        std::fs::create_dir_all(disk.join("taurimmedia546p1")).expect("partition directory");
         std::fs::write(disk.join("removable"), "1").expect("removable flag");
 
         assert_eq!(
-            backing_block_device("/dev/mmcblk0p1", sys_block.path()).as_deref(),
-            Some("mmcblk0")
+            backing_block_device("/dev/taurimmedia546p1", sys_block.path()).as_deref(),
+            Some("taurimmedia546")
         );
         assert!(is_removable_block_device(
-            "/dev/mmcblk0p1",
+            "/dev/taurimmedia546p1",
             sys_block.path()
         ));
     }
@@ -724,12 +724,12 @@ mod linux_tests {
     #[test]
     fn keeps_non_removable_block_mounts_out_of_the_removable_sidebar_group() {
         let sys_block = tempfile::tempdir().expect("temporary sysfs block directory");
-        let disk = sys_block.path().join("nvme0n1");
-        std::fs::create_dir_all(disk.join("nvme0n1p1")).expect("partition directory");
+        let disk = sys_block.path().join("taurifixed546");
+        std::fs::create_dir_all(disk.join("taurifixed546p1")).expect("partition directory");
         std::fs::write(disk.join("removable"), "0").expect("fixed flag");
 
         let drives = parse_linux_block_mounts(
-            "42 35 259:1 / /mnt/data rw,relatime - ext4 /dev/nvme0n1p1 rw\n",
+            "42 35 259:1 / /mnt/data rw,relatime - ext4 /dev/taurifixed546p1 rw\n",
             sys_block.path(),
         );
 

--- a/src-tauri/src/files/drives.rs
+++ b/src-tauri/src/files/drives.rs
@@ -12,6 +12,18 @@ use serde::{Deserialize, Serialize};
 
 use crate::error::AppError;
 
+/// One real filesystem mount reported by Linux's mount table.
+///
+/// Fields stay decoded so callers can use the mount path as the sidebar route
+/// and the device source to determine whether the backing media is removable.
+#[cfg(target_os = "linux")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct LinuxMount {
+    path: String,
+    filesystem: String,
+    source: String,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum DriveKind {

--- a/src-tauri/src/files/drives.rs
+++ b/src-tauri/src/files/drives.rs
@@ -198,14 +198,16 @@ fn is_linux_pseudo_filesystem(filesystem: &str) -> bool {
 }
 
 /// These locations are operating-system roots even when they have a real
-/// block-device backing (for example, a separately mounted `/boot` or `/home`)
-/// and must never be offered as sidebar drives.
+/// block-device backing (for example, a separately mounted `/boot`, its EFI
+/// submount, or `/home`) and must never be offered as sidebar drives.
 #[cfg(target_os = "linux")]
 fn is_linux_system_mount(path: &str) -> bool {
-    matches!(
-        path,
-        "/" | "/boot" | "/home" | "/usr" | "/var" | "/opt" | "/srv" | "/root"
-    )
+    path == "/boot"
+        || path.starts_with("/boot/")
+        || matches!(
+            path,
+            "/" | "/home" | "/usr" | "/var" | "/opt" | "/srv" | "/root"
+        )
 }
 
 #[cfg(target_os = "linux")]

--- a/src-tauri/src/files/drives.rs
+++ b/src-tauri/src/files/drives.rs
@@ -1,7 +1,7 @@
 //! Enumerate drives and volumes across platforms.
 //!
-//! Linux: scans the conventional removable-media directories, GVFS mounts,
-//! and `/proc/self/mountinfo` for rclone cloud mounts.
+//! Linux: reads the mount table for block-device volumes, plus GVFS and rclone
+//! cloud mounts.
 //! macOS: scans `/Volumes/`, skipping the root-mapped system volume.
 //! Windows: iterates drive letters that exist; volume label + provider + type
 //! are read via PowerShell `Win32_LogicalDisk` (no winapi dependency, and unlike
@@ -80,31 +80,14 @@ pub async fn list_drives() -> Result<Vec<Drive>, AppError> {
 
 #[cfg(target_os = "linux")]
 fn enumerate_drives() -> Vec<Drive> {
-    let user = std::env::var("USER").unwrap_or_default();
     let mut seen = std::collections::HashSet::new();
     let mut drives = Vec::new();
 
-    let bases = [
-        format!("/run/media/{}", user),
-        format!("/media/{}", user),
-        "/media".to_string(),
-    ];
-
-    for base in bases.iter() {
-        let Ok(entries) = std::fs::read_dir(base) else {
-            continue;
-        };
-        for entry in entries.flatten() {
-            let name = entry.file_name().to_string_lossy().to_string();
-            // In /media, skip the user's own home-like subdir (which is /media/$USER itself).
-            if !user.is_empty() && name == user {
-                continue;
+    if let Ok(mountinfo) = std::fs::read_to_string("/proc/self/mountinfo") {
+        for drive in parse_linux_block_mounts(&mountinfo, std::path::Path::new("/sys/block")) {
+            if seen.insert(drive.path.clone()) {
+                drives.push(drive);
             }
-            let path = entry.path().to_string_lossy().to_string();
-            if !seen.insert(path.clone()) {
-                continue;
-            }
-            drives.push(Drive::simple(name, path, DriveKind::Removable));
         }
     }
 
@@ -125,6 +108,129 @@ fn enumerate_drives() -> Vec<Drive> {
     }
 
     drives
+}
+
+/// Turn mountinfo records backed by physical block devices into sidebar drives.
+/// This deliberately trusts the kernel mount table rather than a desktop
+/// environment's choice of media directory, so it also covers `/mnt` and fstab
+/// mounts when the app has no `USER` environment variable.
+#[cfg(target_os = "linux")]
+fn parse_linux_block_mounts(mountinfo: &str, sys_block: &std::path::Path) -> Vec<Drive> {
+    parse_linux_mounts(mountinfo)
+        .into_iter()
+        .filter(|mount| !is_linux_pseudo_filesystem(&mount.filesystem))
+        .filter_map(|mount| linux_drive_from_mount(&mount, sys_block))
+        .collect()
+}
+
+#[cfg(target_os = "linux")]
+fn parse_linux_mounts(mountinfo: &str) -> Vec<LinuxMount> {
+    mountinfo.lines().filter_map(parse_linux_mount).collect()
+}
+
+#[cfg(target_os = "linux")]
+fn parse_linux_mount(line: &str) -> Option<LinuxMount> {
+    let (mount_fields, filesystem_fields) = line.split_once(" - ")?;
+    let encoded_path = mount_fields.split_whitespace().nth(4)?;
+    let mut filesystem_fields = filesystem_fields.split_whitespace();
+    let filesystem = filesystem_fields.next()?;
+    let source = filesystem_fields.next()?;
+
+    Some(LinuxMount {
+        path: decode_mountinfo_field(encoded_path),
+        filesystem: filesystem.to_owned(),
+        source: decode_mountinfo_field(source),
+    })
+}
+
+#[cfg(target_os = "linux")]
+fn is_linux_pseudo_filesystem(filesystem: &str) -> bool {
+    matches!(
+        filesystem,
+        "proc"
+            | "sysfs"
+            | "tmpfs"
+            | "devtmpfs"
+            | "devpts"
+            | "overlay"
+            | "squashfs"
+            | "securityfs"
+            | "cgroup"
+            | "cgroup2"
+            | "pstore"
+            | "tracefs"
+            | "debugfs"
+            | "configfs"
+            | "fusectl"
+            | "mqueue"
+            | "hugetlbfs"
+            | "ramfs"
+            | "autofs"
+            | "rpc_pipefs"
+            | "binfmt_misc"
+            | "nsfs"
+    )
+}
+
+#[cfg(target_os = "linux")]
+fn linux_drive_from_mount(mount: &LinuxMount, sys_block: &std::path::Path) -> Option<Drive> {
+    let kind = if is_removable_block_device(&mount.source, sys_block) {
+        DriveKind::Removable
+    } else if backing_block_device(&mount.source, sys_block).is_some() {
+        DriveKind::Fixed
+    } else {
+        return None;
+    };
+    let mount_name = std::path::Path::new(&mount.path).file_name()?.to_str()?;
+    Some(Drive::simple(
+        linux_volume_label(&mount.source).unwrap_or_else(|| mount_name.to_owned()),
+        mount.path.clone(),
+        kind,
+    ))
+}
+
+/// Map a partition such as `sdb1` or `mmcblk0p1` to its parent disk, where
+/// Linux exposes the actual removable flag under `/sys/block`.
+#[cfg(target_os = "linux")]
+fn backing_block_device(source: &str, sys_block: &std::path::Path) -> Option<String> {
+    let source = std::path::Path::new(source);
+    if source.parent()? != std::path::Path::new("/dev") {
+        return None;
+    }
+    let device = source.file_name()?.to_str()?;
+    if sys_block.join(device).is_dir() {
+        return Some(device.to_owned());
+    }
+    std::fs::read_dir(sys_block)
+        .ok()?
+        .flatten()
+        .find_map(|entry| {
+            entry
+                .path()
+                .join(device)
+                .is_dir()
+                .then(|| entry.file_name().to_string_lossy().into_owned())
+        })
+}
+
+#[cfg(target_os = "linux")]
+fn is_removable_block_device(source: &str, sys_block: &std::path::Path) -> bool {
+    backing_block_device(source, sys_block)
+        .and_then(|device| std::fs::read_to_string(sys_block.join(device).join("removable")).ok())
+        .is_some_and(|flag| flag.trim() == "1")
+}
+
+/// Use udev's label aliases when available, otherwise keep the mount name.
+#[cfg(target_os = "linux")]
+fn linux_volume_label(source: &str) -> Option<String> {
+    let source = std::path::Path::new(source).canonicalize().ok()?;
+    std::fs::read_dir("/dev/disk/by-label")
+        .ok()?
+        .flatten()
+        .find_map(|entry| {
+            (entry.path().canonicalize().ok().as_ref() == Some(&source))
+                .then(|| entry.file_name().to_string_lossy().into_owned())
+        })
 }
 
 /// GVFS exposes each connected account as a child of its FUSE mount rather
@@ -613,6 +719,21 @@ mod linux_tests {
             "/dev/mmcblk0p1",
             sys_block.path()
         ));
+    }
+
+    #[test]
+    fn keeps_non_removable_block_mounts_out_of_the_removable_sidebar_group() {
+        let sys_block = tempfile::tempdir().expect("temporary sysfs block directory");
+        let disk = sys_block.path().join("nvme0n1");
+        std::fs::create_dir_all(disk.join("nvme0n1p1")).expect("partition directory");
+        std::fs::write(disk.join("removable"), "0").expect("fixed flag");
+
+        let drives = parse_linux_block_mounts(
+            "42 35 259:1 / /mnt/data rw,relatime - ext4 /dev/nvme0n1p1 rw\n",
+            sys_block.path(),
+        );
+
+        assert!(matches!(drives[0].kind, DriveKind::Fixed));
     }
 
     #[test]

--- a/src-tauri/src/files/drives.rs
+++ b/src-tauri/src/files/drives.rs
@@ -123,6 +123,18 @@ fn parse_linux_block_mounts(mountinfo: &str, sys_block: &std::path::Path) -> Vec
         .collect()
 }
 
+/// Test seam for Linux mount-table fixtures. The production command reads the
+/// real mount table and sysfs roots; integration tests supply deterministic
+/// fixtures without needing to mount a device on the test host.
+#[cfg(target_os = "linux")]
+#[doc(hidden)]
+pub fn parse_linux_block_mounts_for_test(
+    mountinfo: &str,
+    sys_block: &std::path::Path,
+) -> Vec<Drive> {
+    parse_linux_block_mounts(mountinfo, sys_block)
+}
+
 #[cfg(target_os = "linux")]
 fn parse_linux_mounts(mountinfo: &str) -> Vec<LinuxMount> {
     mountinfo.lines().filter_map(parse_linux_mount).collect()

--- a/src-tauri/src/files/drives.rs
+++ b/src-tauri/src/files/drives.rs
@@ -80,16 +80,7 @@ pub async fn list_drives() -> Result<Vec<Drive>, AppError> {
 
 #[cfg(target_os = "linux")]
 fn enumerate_drives() -> Vec<Drive> {
-    let mut seen = std::collections::HashSet::new();
-    let mut drives = Vec::new();
-
-    if let Ok(mountinfo) = std::fs::read_to_string("/proc/self/mountinfo") {
-        for drive in parse_linux_block_mounts(&mountinfo, std::path::Path::new("/sys/block")) {
-            if seen.insert(drive.path.clone()) {
-                drives.push(drive);
-            }
-        }
-    }
+    let mountinfo = std::fs::read_to_string("/proc/self/mountinfo").ok();
 
     let runtime_dir = std::env::var_os("XDG_RUNTIME_DIR")
         .map(std::path::PathBuf::from)
@@ -98,10 +89,33 @@ fn enumerate_drives() -> Vec<Drive> {
             let uid = unsafe { libc::geteuid() };
             std::path::PathBuf::from(format!("/run/user/{uid}"))
         });
-    for drive in linux_gvfs_google_drives(&runtime_dir.join("gvfs"))
+    let cloud_drives = linux_gvfs_google_drives(&runtime_dir.join("gvfs"))
         .into_iter()
-        .chain(linux_rclone_drives())
-    {
+        .chain(linux_rclone_drives());
+
+    enumerate_linux_drives(
+        mountinfo.as_deref(),
+        std::path::Path::new("/sys/block"),
+        cloud_drives,
+    )
+}
+
+/// The shared production enumeration path. The native command supplies the
+/// real mount table and sysfs root; tests supply fixtures through the same
+/// filtering, classification, de-duplication, and removal behavior.
+#[cfg(target_os = "linux")]
+fn enumerate_linux_drives(
+    mountinfo: Option<&str>,
+    sys_block: &std::path::Path,
+    cloud_drives: impl IntoIterator<Item = Drive>,
+) -> Vec<Drive> {
+    let mut seen = std::collections::HashSet::new();
+    let mut drives = mountinfo
+        .map(|contents| parse_linux_block_mounts(contents, sys_block))
+        .unwrap_or_default();
+    seen.extend(drives.iter().map(|drive| drive.path.clone()));
+
+    for drive in cloud_drives {
         if seen.insert(drive.path.clone()) {
             drives.push(drive);
         }
@@ -119,20 +133,19 @@ fn parse_linux_block_mounts(mountinfo: &str, sys_block: &std::path::Path) -> Vec
     parse_linux_mounts(mountinfo)
         .into_iter()
         .filter(|mount| !is_linux_pseudo_filesystem(&mount.filesystem))
+        .filter(|mount| !is_linux_system_mount(&mount.path))
         .filter_map(|mount| linux_drive_from_mount(&mount, sys_block))
         .collect()
 }
 
-/// Test seam for Linux mount-table fixtures. The production command reads the
-/// real mount table and sysfs roots; integration tests supply deterministic
-/// fixtures without needing to mount a device on the test host.
+/// Controlled input seam for the real Linux drive enumeration path.
+///
+/// This exists for integration tests that need deterministic mount-table and
+/// sysfs fixtures without mounting or unmounting hardware on the test host.
 #[cfg(target_os = "linux")]
 #[doc(hidden)]
-pub fn parse_linux_block_mounts_for_test(
-    mountinfo: &str,
-    sys_block: &std::path::Path,
-) -> Vec<Drive> {
-    parse_linux_block_mounts(mountinfo, sys_block)
+pub fn enumerate_linux_drives_for_test(mountinfo: &str, sys_block: &std::path::Path) -> Vec<Drive> {
+    enumerate_linux_drives(Some(mountinfo), sys_block, std::iter::empty())
 }
 
 #[cfg(target_os = "linux")]
@@ -181,6 +194,17 @@ fn is_linux_pseudo_filesystem(filesystem: &str) -> bool {
             | "rpc_pipefs"
             | "binfmt_misc"
             | "nsfs"
+    )
+}
+
+/// These locations are operating-system roots even when they have a real
+/// block-device backing (for example, a separately mounted `/boot` or `/home`)
+/// and must never be offered as sidebar drives.
+#[cfg(target_os = "linux")]
+fn is_linux_system_mount(path: &str) -> bool {
+    matches!(
+        path,
+        "/" | "/boot" | "/home" | "/usr" | "/var" | "/opt" | "/srv" | "/root"
     )
 }
 

--- a/src-tauri/src/files/drives.rs
+++ b/src-tauri/src/files/drives.rs
@@ -564,6 +564,58 @@ mod linux_tests {
     use super::*;
 
     #[test]
+    fn exposes_removable_mounts_from_any_mount_path_without_user_environment() {
+        let sys_block = tempfile::tempdir().expect("temporary sysfs block directory");
+        let disk = sys_block.path().join("sdb");
+        std::fs::create_dir_all(disk.join("sdb1")).expect("partition directory");
+        std::fs::write(disk.join("removable"), "1\n").expect("removable flag");
+
+        let drives = parse_linux_block_mounts(
+            "42 35 8:17 / /mnt/USB\\040BACKUP rw,relatime - ext4 /dev/sdb1 rw\n",
+            sys_block.path(),
+        );
+
+        assert_eq!(drives.len(), 1);
+        assert_eq!(drives[0].name, "USB BACKUP");
+        assert_eq!(drives[0].path, "/mnt/USB BACKUP");
+        assert!(matches!(drives[0].kind, DriveKind::Removable));
+    }
+
+    #[test]
+    fn filters_pseudo_filesystems_and_malformed_mountinfo() {
+        let sys_block = tempfile::tempdir().expect("temporary sysfs block directory");
+        let mountinfo = concat!(
+            "malformed mountinfo line\n",
+            "1 0 0:1 / /proc rw - proc proc rw\n",
+            "2 0 0:2 / /sys rw - sysfs sysfs rw\n",
+            "3 0 0:3 / /run rw - tmpfs tmpfs rw\n",
+            "4 0 0:4 / /sys/fs/cgroup rw - cgroup2 cgroup rw\n",
+            "5 0 0:5 / /dev/pts rw - devpts devpts rw\n",
+            "6 0 0:6 / / rw - overlay overlay rw\n",
+            "7 0 7:0 / /snap/example rw - squashfs /dev/loop0 rw\n",
+        );
+
+        assert!(parse_linux_block_mounts(mountinfo, sys_block.path()).is_empty());
+    }
+
+    #[test]
+    fn resolves_partition_to_its_backing_disk_removable_flag() {
+        let sys_block = tempfile::tempdir().expect("temporary sysfs block directory");
+        let disk = sys_block.path().join("mmcblk0");
+        std::fs::create_dir_all(disk.join("mmcblk0p1")).expect("partition directory");
+        std::fs::write(disk.join("removable"), "1").expect("removable flag");
+
+        assert_eq!(
+            backing_block_device("/dev/mmcblk0p1", sys_block.path()).as_deref(),
+            Some("mmcblk0")
+        );
+        assert!(is_removable_block_device(
+            "/dev/mmcblk0p1",
+            sys_block.path()
+        ));
+    }
+
+    #[test]
     fn discovers_gvfs_google_account_with_account_detail() {
         let gvfs = tempfile::tempdir().expect("temporary GVFS directory");
         let mount = gvfs.path().join("google-drive:host=user@example.com");

--- a/src-tauri/tests/linux_drives_mounts.rs
+++ b/src-tauri/tests/linux_drives_mounts.rs
@@ -1,0 +1,21 @@
+#![cfg(target_os = "linux")]
+
+use tauri_explorer_lib::files::drives::parse_linux_block_mounts_for_test;
+
+#[test]
+fn removable_mountinfo_entry_becomes_a_sidebar_drive() {
+    let sys_block = tempfile::tempdir().expect("temporary sysfs block directory");
+    let disk = sys_block.path().join("tauriintegration546");
+    std::fs::create_dir_all(disk.join("tauriintegration546p1")).expect("partition directory");
+    std::fs::write(disk.join("removable"), "1\n").expect("removable flag");
+
+    let drives = parse_linux_block_mounts_for_test(
+        "42 35 8:17 / /mnt/USB\\040BACKUP rw,relatime - ext4 /dev/tauriintegration546p1 rw\n",
+        sys_block.path(),
+    );
+
+    assert_eq!(drives.len(), 1);
+    assert_eq!(drives[0].name, "USB BACKUP");
+    assert_eq!(drives[0].path, "/mnt/USB BACKUP");
+    assert_eq!(serde_json::to_value(&drives[0].kind).unwrap(), "removable");
+}

--- a/src-tauri/tests/linux_drives_mounts.rs
+++ b/src-tauri/tests/linux_drives_mounts.rs
@@ -31,7 +31,8 @@ fn system_block_mounts_do_not_become_sidebar_drives() {
     let drives = enumerate_linux_drives_for_test(
         concat!(
             "1 0 8:1 / /boot rw - ext4 /dev/taurisystem546p1 rw\n",
-            "2 0 8:1 / /home rw - ext4 /dev/taurisystem546p1 rw\n",
+            "2 0 8:1 / /boot/efi rw - vfat /dev/taurisystem546p1 rw\n",
+            "3 0 8:1 / /home rw - ext4 /dev/taurisystem546p1 rw\n",
         ),
         sys_block.path(),
     );

--- a/src-tauri/tests/linux_drives_mounts.rs
+++ b/src-tauri/tests/linux_drives_mounts.rs
@@ -1,21 +1,40 @@
 #![cfg(target_os = "linux")]
 
-use tauri_explorer_lib::files::drives::parse_linux_block_mounts_for_test;
+use tauri_explorer_lib::files::drives::enumerate_linux_drives_for_test;
 
 #[test]
-fn removable_mountinfo_entry_becomes_a_sidebar_drive() {
+fn removable_mount_table_entry_becomes_a_sidebar_drive_and_disappears_after_unmount() {
     let sys_block = tempfile::tempdir().expect("temporary sysfs block directory");
     let disk = sys_block.path().join("tauriintegration546");
     std::fs::create_dir_all(disk.join("tauriintegration546p1")).expect("partition directory");
     std::fs::write(disk.join("removable"), "1\n").expect("removable flag");
 
-    let drives = parse_linux_block_mounts_for_test(
+    let mounted = enumerate_linux_drives_for_test(
         "42 35 8:17 / /mnt/USB\\040BACKUP rw,relatime - ext4 /dev/tauriintegration546p1 rw\n",
         sys_block.path(),
     );
 
-    assert_eq!(drives.len(), 1);
-    assert_eq!(drives[0].name, "USB BACKUP");
-    assert_eq!(drives[0].path, "/mnt/USB BACKUP");
-    assert_eq!(serde_json::to_value(&drives[0].kind).unwrap(), "removable");
+    assert_eq!(mounted.len(), 1);
+    assert_eq!(mounted[0].name, "USB BACKUP");
+    assert_eq!(mounted[0].path, "/mnt/USB BACKUP");
+    assert_eq!(serde_json::to_value(&mounted[0].kind).unwrap(), "removable");
+    assert!(enumerate_linux_drives_for_test("", sys_block.path()).is_empty());
+}
+
+#[test]
+fn system_block_mounts_do_not_become_sidebar_drives() {
+    let sys_block = tempfile::tempdir().expect("temporary sysfs block directory");
+    let disk = sys_block.path().join("taurisystem546");
+    std::fs::create_dir_all(disk.join("taurisystem546p1")).expect("partition directory");
+    std::fs::write(disk.join("removable"), "0\n").expect("fixed flag");
+
+    let drives = enumerate_linux_drives_for_test(
+        concat!(
+            "1 0 8:1 / /boot rw - ext4 /dev/taurisystem546p1 rw\n",
+            "2 0 8:1 / /home rw - ext4 /dev/taurisystem546p1 rw\n",
+        ),
+        sys_block.path(),
+    );
+
+    assert!(drives.is_empty());
 }


### PR DESCRIPTION
## Summary

- enumerate Linux block-device mounts from `/proc/self/mountinfo` instead of mount-directory conventions
- classify partition-backed media from the parent disk’s sysfs `removable` flag and use udev volume labels when available
- exclude OS-root mounts and `/boot/*` submounts, while retaining cloud-drive discovery

## Acceptance Criteria

- [ ] A removable device mounted at `/mnt` is returned by `list_drives` as `removable`, with its decoded mount path and volume label (or mount name fallback).
- [ ] `list_drives` does not depend on `USER`, so desktop-launched Linux sessions discover mount-table media.
- [ ] Pseudo and operating-system filesystems, including separately mounted `/boot`, `/boot/efi`, and `/home`, are excluded from the returned drive list.
- [ ] A device absent from the current mount table is absent from the next `list_drives` result, allowing the existing sidebar poll to remove it.

## Test Plan

- `cd src-tauri && cargo test`
- Integration coverage calls the shared production enumeration path with controlled mountinfo/sysfs fixtures, proving a `/mnt` removable device is returned, system mounts (including `/boot/efi`) are excluded, and the next empty mount table removes the device. Unit coverage retains pseudo/malformed mountinfo and partition-classification cases.

## Review Notes

- Addressed review finding 1 by excluding explicit operating-system mount roots before block-device classification, including the `/boot/*` subtree and a `/boot/efi` regression case.
- Addressed review finding 2 by moving the integration test from the parser helper to the shared production enumeration path; the production command provides real readers and the test seam provides deterministic readers.

Fixes #546