### PR TITLE
fix: diagnose Windows Tauri smoke session hang

### DIFF
--- a/.github/workflows/e2e-tauri.yml
+++ b/.github/workflows/e2e-tauri.yml
@@ -72,40 +72,19 @@ jobs:
         shell: bash
         run: bun install --frozen-lockfile
 
-      - name: Build frontend
-        run: bun run build
-
-      - name: Build Tauri binary (debug, no bundle)
+      # Build through the Tauri CLI, not `cargo build`. A bare cargo debug
+      # build omits the `tauri/custom-protocol` feature, so the binary serves
+      # `build.devUrl` (localhost:1420) and the suite needs a Vite dev server
+      # alongside it. That coupling is what broke Windows (#457): the webview's
+      # first paint blocks on a cold dev server transforming the whole module
+      # graph, msedgedriver's new-session waits for that load, and once the
+      # graph outgrew the 60s connectionRetryTimeout the handshake never
+      # returned — the session POST died with hyper IncompleteMessage on every
+      # run. `tauri build --debug` passes custom-protocol, so the frontend is
+      # embedded in the binary and there is no dev server to race.
+      - name: Build Tauri binary (debug, embedded frontend, no bundle)
         shell: bash
-        run: cargo build --manifest-path src-tauri/Cargo.toml
-
-      # Debug-profile tauri binaries embed build.devUrl (localhost:1420)
-      # instead of the bundled frontend — the webview is blank unless the
-      # dev server is up.
-      - name: Start frontend dev server (Linux)
-        if: runner.os == 'Linux'
-        run: |
-          nohup bun run dev > /tmp/vite.log 2>&1 &
-          for i in $(seq 1 60); do
-            curl -sf http://localhost:1420 > /dev/null && exit 0
-            sleep 1
-          done
-          echo "dev server never came up" >&2
-          cat /tmp/vite.log >&2
-          exit 1
-
-      - name: Start frontend dev server (Windows)
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          Start-Process bun -ArgumentList 'run','dev' -WindowStyle Hidden -RedirectStandardOutput "$env:RUNNER_TEMP\vite.log" -RedirectStandardError "$env:RUNNER_TEMP\vite-error.log"
-          foreach ($i in 1..60) {
-            try {
-              Invoke-WebRequest -UseBasicParsing http://localhost:1420 | Out-Null
-              exit 0
-            } catch { Start-Sleep -Seconds 1 }
-          }
-          Write-Error "dev server never came up"
+        run: bun run tauri build --debug --no-bundle
 
       - name: Run smoke suite (Linux, under Xvfb)
         if: runner.os == 'Linux'
@@ -141,6 +120,4 @@ jobs:
           path: |
             logs/
             e2e-tauri/logs/
-            ${{ runner.temp }}/vite.log
-            ${{ runner.temp }}/vite-error.log
           if-no-files-found: ignore

--- a/.github/workflows/e2e-tauri.yml
+++ b/.github/workflows/e2e-tauri.yml
@@ -109,9 +109,10 @@ jobs:
 
       - name: Run smoke suite (Windows)
         if: runner.os == 'Windows'
-        # Keep the outer 25-minute job cap as a safeguard, but leave time for
-        # the always() artifact step when the driver/session handshake stalls.
-        timeout-minutes: 3
+        # A passing serial smoke suite needs most of the previous 25-minute
+        # budget. Stop a true stall at 15 minutes so the outer job still has
+        # ten minutes to run the always() artifact upload.
+        timeout-minutes: 15
         env:
           # The diagnostic run exits after the first session failure; a later
           # green change removes this guard once the real handshake is fixed.

--- a/.github/workflows/e2e-tauri.yml
+++ b/.github/workflows/e2e-tauri.yml
@@ -102,7 +102,7 @@ jobs:
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
-          Start-Process bun -ArgumentList 'run','dev' -WindowStyle Hidden
+          Start-Process bun -ArgumentList 'run','dev' -WindowStyle Hidden -RedirectStandardOutput "$env:RUNNER_TEMP\vite.log" -RedirectStandardError "$env:RUNNER_TEMP\vite-error.log"
           foreach ($i in 1..60) {
             try {
               Invoke-WebRequest -UseBasicParsing http://localhost:1420 | Out-Null
@@ -131,14 +131,20 @@ jobs:
 
       - name: Run smoke suite (Windows)
         if: runner.os == 'Windows'
+        env:
+          # The diagnostic run exits after the first session failure; a later
+          # green change removes this guard once the real handshake is fixed.
+          TAURI_E2E_DIAGNOSTIC: "1"
         run: bun run test:e2e:tauri
 
-      - name: Upload WDIO logs on failure
-        if: failure()
+      - name: Upload WDIO lifecycle logs
+        if: always()
         uses: actions/upload-artifact@v7
         with:
           name: wdio-logs-${{ matrix.os }}
           path: |
             logs/
             e2e-tauri/logs/
+            ${{ runner.temp }}/vite.log
+            ${{ runner.temp }}/vite-error.log
           if-no-files-found: ignore

--- a/.github/workflows/e2e-tauri.yml
+++ b/.github/workflows/e2e-tauri.yml
@@ -84,7 +84,10 @@ jobs:
       # embedded in the binary and there is no dev server to race.
       - name: Build Tauri binary (debug, embedded frontend, no bundle)
         shell: bash
-        run: bun run tauri build --debug --no-bundle
+        run: |
+          mkdir -p e2e-tauri/logs
+          set -o pipefail
+          bun run tauri build --debug --no-bundle 2>&1 | tee e2e-tauri/logs/tauri-build.log
 
       - name: Run smoke suite (Linux, under Xvfb)
         if: runner.os == 'Linux'
@@ -106,6 +109,9 @@ jobs:
 
       - name: Run smoke suite (Windows)
         if: runner.os == 'Windows'
+        # Keep the outer 25-minute job cap as a safeguard, but leave time for
+        # the always() artifact step when the driver/session handshake stalls.
+        timeout-minutes: 3
         env:
           # The diagnostic run exits after the first session failure; a later
           # green change removes this guard once the real handshake is fixed.

--- a/.github/workflows/e2e-tauri.yml
+++ b/.github/workflows/e2e-tauri.yml
@@ -17,7 +17,10 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 25
+    # Setup (including the Tauri build) happens before the bounded smoke step.
+    # Keep enough outer budget for that setup, a full 15-minute smoke run, and
+    # the always() diagnostics artifact after a timeout.
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v7
 
@@ -109,9 +112,8 @@ jobs:
 
       - name: Run smoke suite (Windows)
         if: runner.os == 'Windows'
-        # A passing serial smoke suite needs most of the previous 25-minute
-        # budget. Stop a true stall at 15 minutes so the outer job still has
-        # ten minutes to run the always() artifact upload.
+        # Stop a true stall at 15 minutes; the 45-minute outer job budget
+        # reserves time for setup and the always() artifact upload.
         timeout-minutes: 15
         env:
           # The diagnostic run exits after the first session failure; a later

--- a/.github/workflows/e2e-tauri.yml
+++ b/.github/workflows/e2e-tauri.yml
@@ -87,6 +87,10 @@ jobs:
       # embedded in the binary and there is no dev server to race.
       - name: Build Tauri binary (debug, embedded frontend, no bundle)
         shell: bash
+        env:
+          # Preserve the test-only DOM hooks in the embedded frontend. They
+          # drive real backend operations without reintroducing a Vite server.
+          VITE_TAURI_E2E: "1"
         run: |
           mkdir -p e2e-tauri/logs
           set -o pipefail

--- a/.github/workflows/e2e-tauri.yml
+++ b/.github/workflows/e2e-tauri.yml
@@ -10,16 +10,12 @@ on:
 # Note: macOS is deliberately omitted. Official `tauri-driver` has no
 # WKWebView support (tauri-apps/tauri#7068). Re-add when a stable driver
 # exists or if macOS regressions justify the CrabNebula subscription.
-# The windows-latest leg hung at the job cap on every recorded push run
-# (builds green, smoke suite never completes — see #478), so it only runs on
-# manual dispatch. Windows coverage is a local run on real hardware instead:
-# pull on the Windows machine and `bun run test:e2e:tauri`.
 jobs:
   smoke:
     strategy:
       fail-fast: false
       matrix:
-        os: ${{ github.event_name == 'workflow_dispatch' && fromJSON('["ubuntu-latest", "windows-latest"]') || fromJSON('["ubuntu-latest"]') }}
+        os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 25
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,26 +4,26 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Build & Dev Commands
 
-| Task | Command |
-|------|---------|
-| Dev server (frontend only) | `bun run dev` |
-| Dev server (full Tauri app) | `bun run start` |
-| Clean rebuild | `bun run clean` (full) or `bun run clean:fast` (skip Rust) |
-| Type check | `bun run check` |
-| Unit tests | `bun run test` |
-| Single unit test file | `bunx vitest run tests/path/to/file.test.ts` |
-| E2E tests (default view) | `bun run test:e2e` |
-| E2E tests (all view modes) | `ALL_VIEW_MODES=1 npx playwright test` |
-| E2E tests (WebKit ≈ WKWebView proxy) | `WEBKIT=1 npx playwright test --project=webkit` (on Arch: prepend `PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS=true`; Ubuntu-only libs live in the webkit bundle's `sys/lib`) |
-| Single E2E test | `npx playwright test e2e/specific.spec.ts` |
-| Tauri-binary E2E (Linux/Windows only) | `bun run test:e2e:tauri` (needs `cargo install tauri-driver`, `webkit2gtk-driver` on Linux, a debug binary, and a dev server on :1420) |
-| Performance tests | `bun run test:perf` |
-| High-load stress tests | `bun run test:load` (own Playwright config on :1430; many git-graph tabs, leak churn, CPU throttle, 256MB heap cap; `LOAD_CYCLES=N` scales churn) |
-| Rust criterion benches | `bun run bench:rust` (baselines recorded in `src-tauri/benches/*.rs` header comments) |
-| Bundle-size budget check | `bun run check:bundle` (builds frontend, fails if main chunk gzip exceeds budget in `scripts/check-bundle-size.mjs`) |
-| Rust build only | `cd src-tauri && cargo build` |
-| Runnable release binary | `bun run build && cd src-tauri && cargo build --release --features tauri/custom-protocol` — a bare `cargo build --release` yields a DEV-mode binary that dials localhost:1420 (Tauri gates prod on the `custom-protocol` feature, which only the Tauri CLI passes) |
-| Rust tests only | `cd src-tauri && cargo test` |
+| Task                                  | Command                                                                                                                                                                                                                                                                                                                              |
+| ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Dev server (frontend only)            | `bun run dev`                                                                                                                                                                                                                                                                                                                        |
+| Dev server (full Tauri app)           | `bun run start`                                                                                                                                                                                                                                                                                                                      |
+| Clean rebuild                         | `bun run clean` (full) or `bun run clean:fast` (skip Rust)                                                                                                                                                                                                                                                                           |
+| Type check                            | `bun run check`                                                                                                                                                                                                                                                                                                                      |
+| Unit tests                            | `bun run test`                                                                                                                                                                                                                                                                                                                       |
+| Single unit test file                 | `bunx vitest run tests/path/to/file.test.ts`                                                                                                                                                                                                                                                                                         |
+| E2E tests (default view)              | `bun run test:e2e`                                                                                                                                                                                                                                                                                                                   |
+| E2E tests (all view modes)            | `ALL_VIEW_MODES=1 npx playwright test`                                                                                                                                                                                                                                                                                               |
+| E2E tests (WebKit ≈ WKWebView proxy)  | `WEBKIT=1 npx playwright test --project=webkit` (on Arch: prepend `PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS=true`; Ubuntu-only libs live in the webkit bundle's `sys/lib`)                                                                                                                                                         |
+| Single E2E test                       | `npx playwright test e2e/specific.spec.ts`                                                                                                                                                                                                                                                                                           |
+| Tauri-binary E2E (Linux/Windows only) | `bun run test:e2e:tauri` (needs `cargo install tauri-driver`, `webkit2gtk-driver` on Linux, and a binary built via `bun run tauri build --debug --no-bundle` — build it with the Tauri CLI, not `cargo build`, or it serves `devUrl` and the suite silently depends on a dev server on :1420, which is what hung Windows CI in #457) |
+| Performance tests                     | `bun run test:perf`                                                                                                                                                                                                                                                                                                                  |
+| High-load stress tests                | `bun run test:load` (own Playwright config on :1430; many git-graph tabs, leak churn, CPU throttle, 256MB heap cap; `LOAD_CYCLES=N` scales churn)                                                                                                                                                                                    |
+| Rust criterion benches                | `bun run bench:rust` (baselines recorded in `src-tauri/benches/*.rs` header comments)                                                                                                                                                                                                                                                |
+| Bundle-size budget check              | `bun run check:bundle` (builds frontend, fails if main chunk gzip exceeds budget in `scripts/check-bundle-size.mjs`)                                                                                                                                                                                                                 |
+| Rust build only                       | `cd src-tauri && cargo build`                                                                                                                                                                                                                                                                                                        |
+| Runnable release binary               | `bun run build && cd src-tauri && cargo build --release --features tauri/custom-protocol` — a bare `cargo build --release` yields a DEV-mode binary that dials localhost:1420 (Tauri gates prod on the `custom-protocol` feature, which only the Tauri CLI passes)                                                                   |
+| Rust tests only                       | `cd src-tauri && cargo test`                                                                                                                                                                                                                                                                                                         |
 
 ### WSL ↔ Windows: always `git push` after committing
 
@@ -36,6 +36,7 @@ When developing in WSL (e.g. on the `windows` branch), the Windows side builds/t
 Frontend layers (`src/lib/`): `domain/` (pure logic, no framework deps — put business logic here), `state/` (rune stores), `api/` (IPC wrappers; `mock-invoke.ts` fakes the backend outside Tauri, detected via `__TAURI_INTERNALS__`), `composables/`, `components/`, `themes/`. Backend (`src-tauri/src/`): all Tauri commands must be `async fn` (sync blocks the main thread). Entry point `src/routes/+page.svelte` composes the layout and owns global shortcuts.
 
 Rules that bite:
+
 - Three view modes (Details/List/Tiles) dispatched by `FileList.svelte` — display features must land in all three.
 - Keep high-frequency hover feedback on file entries, sidebar navigation, and tabs immediate. Preserve motion for one-shot structural events (such as tab enter/close), but do not add CSS transition settling to pointer highlights; it reads as input latency even when the main thread is idle (#503).
 - Refresh policy is split deliberately: WHEN=`refresh-manager`, WHETHER=`pane-watch`, HOW=`pane-refresh`. Don't add a fourth gate, and don't build private refresh stacks inside components — the git graph did, and it produced #431/#432.
@@ -110,7 +111,7 @@ The public report relay under `website/api/` uses `GITHUB_ISSUE_TOKEN` only for 
 
 **Repro-first for bug fixes.** Before changing logic, write the test that fails for the reported reason (or demonstrate the failure at the pre-fix commit). Gold standard: the test passes on your branch and fails with the fix reverted. If the buggy logic has no importable seam, extracting the seam is part of the fix — don't settle for verifying a transcribed copy.
 
-**Adversarial verification for high-risk changes.** Concurrency, caching, perf claims, and anything self-graded by its implementer gets a separate verifier (a subagent with no stake in the claims) that tries to *falsify* each claim — staleness attacks on caches, interleaving attacks on async flows, measured numbers for perf claims — and reports CONFIRMED / PLAUSIBLE / REFUTED per claim. This found real bugs both times it was run; budget for it on any structural change.
+**Adversarial verification for high-risk changes.** Concurrency, caching, perf claims, and anything self-graded by its implementer gets a separate verifier (a subagent with no stake in the claims) that tries to _falsify_ each claim — staleness attacks on caches, interleaving attacks on async flows, measured numbers for perf claims — and reports CONFIRMED / PLAUSIBLE / REFUTED per claim. This found real bugs both times it was run; budget for it on any structural change.
 
 **E2E tests assert outcomes**, not existence — a QuickOpen test verifies results appear for a query, not that the modal opened.
 
@@ -125,7 +126,7 @@ SCM archive actions preserve each repo-relative path under `.archive/` and add
 
 ## Delegation & Subagent Worktrees
 
-- If the main model is Fable, tokens are very expensive, so whenever possible delegate work to Opus and Sonnet subagents. Use Fable only for high level synthesis and understanding. Do NOT use Fable subagents unless explicitly instructed to. 
+- If the main model is Fable, tokens are very expensive, so whenever possible delegate work to Opus and Sonnet subagents. Use Fable only for high level synthesis and understanding. Do NOT use Fable subagents unless explicitly instructed to.
 - Agent-tool worktrees are created from **main**, not `dev`: a delegated agent must start by branching from `origin/dev` (or the coordinator's integration branch), and the coordinator verifies `git merge-base` before merging.
 - Agents work **only inside their worktree cwd with relative paths**. Absolute paths leak edits into the main checkout — it has happened; coordinators should spot-check `git -C <main-repo> status` while agents run.
 - Port :1420 belongs to the main session. Agents needing a dev server or E2E run use their own port with a throwaway config.

--- a/docs/adr/0006-tauri-e2e-driver-lifecycle.md
+++ b/docs/adr/0006-tauri-e2e-driver-lifecycle.md
@@ -1,0 +1,34 @@
+# ADR 0006: Tauri E2E driver lifecycle
+
+Status: Accepted
+
+Governs: `e2e-tauri/wdio.conf.ts`, `.github/workflows/e2e-tauri.yml`
+
+## Context
+
+The real-binary smoke suite launches `tauri-driver`, which in turn owns the
+native WebDriver process and the Tauri application. A session-start failure can
+otherwise leave the runner with no durable record of the driver transcript, or
+consume the job-level timeout before GitHub Actions can upload diagnostics.
+
+## Decision
+
+- The WDIO worker owns the `tauri-driver` child it spawns. It pipes both child
+  streams to the worker console and to a per-worker log file; it records spawn
+  errors and closes that log only after the child exit event.
+- Session teardown requests child termination. The child exit event is the
+  single reaping observation and records its exit code or signal.
+- Normal runs execute every smoke spec. A diagnostic environment may stop after
+  the first failed session so its transcript is preserved rather than repeating
+  the same failed handshake through the job cap.
+- The workflow bounds the Windows smoke step at 15 minutes but gives the job a
+  larger outer budget for checkout, dependency installation, build work, and
+  the `always()` artifact upload. Build output and WDIO/driver logs are saved
+  under `e2e-tauri/logs/` and uploaded after either success or failure.
+
+## Consequences
+
+Changes to driver spawn ownership, termination, stream handling, log flushing,
+or timeout/failure behavior must keep a single worker owner and retain an
+observable transcript. CI timeout changes must reserve job time for artifact
+upload; a job-level timeout alone is not diagnostic evidence.

--- a/docs/adr/0006-tauri-e2e-driver-lifecycle.md
+++ b/docs/adr/0006-tauri-e2e-driver-lifecycle.md
@@ -15,8 +15,9 @@ consume the job-level timeout before GitHub Actions can upload diagnostics.
 
 - The WDIO worker owns the `tauri-driver` child it spawns. It pipes both child
   streams to the worker console and to a per-worker log file; it records spawn
-  errors and closes that log only after the child exit event.
-- Session teardown requests child termination. The child exit event is the
+  errors and closes that log only after the child close event, when both output
+  streams have drained.
+- Session teardown requests child termination. The child close event is the
   single reaping observation and records its exit code or signal.
 - Normal runs execute every smoke spec. A diagnostic environment may stop after
   the first failed session so its transcript is preserved rather than repeating

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -11,3 +11,4 @@ decision during review.
 | [0003](0003-windows-installer-trust-boundary.md) | Windows installer trust boundary | Accepted |
 | [0004](0004-config-watcher-lifecycle.md) | Config watcher lifecycle and symlink refresh | Accepted |
 | [0005](0005-github-pr-conversation-boundary.md) | GitHub PR conversation data boundary | Accepted |
+| [0006](0006-tauri-e2e-driver-lifecycle.md) | Tauri E2E driver lifecycle | Accepted |

--- a/docs/code-map/map-feature.md
+++ b/docs/code-map/map-feature.md
@@ -48,6 +48,8 @@ backend for E2E/browser).
 - `composables/use-file-watchers.ts` — subscribes to `directory-changed` + cross-window channel
 - `state/file-events.ts` — BroadcastChannel `explorer-file-changes` between windows
 - `api/files.ts` — `watchDirectory`/`unwatchDirectory`, `listDirectory`, `startStreamingDirectory`
+- `src/lib/e2e-mode.ts` — enables the real-binary suite's DOM probes in the explicitly
+  opted-in embedded smoke build without exposing them in ordinary production builds
 - `src-tauri/src/files/fs_watcher.rs` — notify watcher → emits event; `files/dir_listing.rs` — listing + streaming
 - FLOW: `directory-changed` (fs_watcher.rs → use-file-watchers.ts) and cross-window `broadcastFileChange` both funnel through `requestRefresh` → pane `refresh()`. Refresh policy split across 3 layers — read header of `refresh-manager.ts` before touching.
 

--- a/docs/code-map/map-folder.md
+++ b/docs/code-map/map-folder.md
@@ -15,6 +15,10 @@ Layout: frontend `src/lib/` (components / state / api / composables / domain / p
 - `+layout.ts` — SvelteKit adapter-static SPA config (prerender/ssr flags). Rarely touched.
 - `src/hooks.client.ts` — SPA client entry; installs global crash/error handlers before the app mounts (catches early init errors).
 
+## src/lib/ — shared frontend modules.
+- `src/lib/e2e-mode.ts` — build-time gate for test-only hooks: enabled in Vite dev or
+  the explicitly opted-in embedded Tauri smoke build, never a normal production build.
+
 ## src/lib/components/ — Svelte 5 UI. Views, dialogs, panels, item chrome.
 - `FileList.svelte` — dispatches to Details/List/Tiles by view mode; hosts marquee, drop, empty-state. Central view entry.
 - `DetailsView.svelte` — virtual-scrolled table view (columns, resize, sort headers).

--- a/docs/lessons/457-windows-tauri-smoke-hang.md
+++ b/docs/lessons/457-windows-tauri-smoke-hang.md
@@ -1,0 +1,75 @@
+# #457 — Windows Tauri smoke hung because the debug binary needed a dev server
+
+## Symptom
+
+From 2026-07-17 the `windows-latest` leg of `Tauri binary E2E (smoke)` consumed
+its whole 25-minute `timeout-minutes` cap on every run. Build steps were green;
+only "Run smoke suite (Windows)" hung. `ubuntu-latest` ran the same suite in
+8–9 minutes. 20+ consecutive runs, no flake — a hard cliff.
+
+## What the diagnostic run showed
+
+Bounding the run (`bail` after the first session failure) turned the timeout
+into a readable failure in 61 seconds:
+
+```
+[0-0] [tauri-e2e] spawning driver for ...\target\debug\tauri-explorer.exe
+[0-0] [Perf] main() pre-run: 316.6µs          <- the app process DID start
+[0-0] Error serving connection: hyper::Error(IncompleteMessage)
+✖ Failed to create a session:
+WebDriverError: The operation was aborted due to timeout when running
+"http://127.0.0.1:4444/session" with method "POST"
+```
+
+The app launched. `POST /session` then hung for exactly `connectionRetryTimeout`
+(60 s) and WDIO aborted mid-request, which is what tauri-driver's hyper server
+reports as `IncompleteMessage`. So the failure was inside the new-session
+handshake, not in spawn, not in a spec.
+
+## Root cause
+
+`cargo build --manifest-path src-tauri/Cargo.toml` produces a **dev-mode**
+binary. Tauri gates production asset embedding on the `tauri/custom-protocol`
+feature, which only the Tauri CLI passes — a bare `cargo build` therefore leaves
+the webview pointed at `build.devUrl` (`http://localhost:1420`). The workflow
+compensated by starting a Vite dev server next to the binary.
+
+msedgedriver's `POST /session` does not return until the WebView2 page finishes
+loading. That load was a **cold** Vite dev server — started one second earlier —
+transforming the entire module graph on demand. On the Windows runner that
+exceeded 60 s; on Linux it did not. Nothing about Windows was broken. The suite
+had a hidden dependency on dev-server cold-start latency, and the module graph
+crossed the 60 s line in July.
+
+The Jul 17 break window pointed at the git-graph _spec_ work, which was a red
+herring: the git-graph _feature_ work in the same window grew the module graph.
+
+## Fix
+
+Build the smoke binary through the Tauri CLI so the frontend is embedded and no
+dev server exists to race:
+
+```bash
+bun run tauri build --debug --no-bundle
+```
+
+Both dev-server steps were deleted from the workflow. This also removes the
+Linux leg's dependency on the same latency, and makes the binary under test
+closer to what actually ships.
+
+## Transferable lesson
+
+A test harness that needs a dev server alongside the binary has a **timing**
+dependency, not just a setup dependency — it will degrade silently as the app
+grows and then fail as a cliff. Prefer the shipped asset path.
+
+Corollary already recorded elsewhere in this repo, now with a second victim:
+`cargo build [--release]` never yields a production-mode Tauri binary. If you
+did not go through the Tauri CLI, the webview is dialing localhost.
+
+## Diagnosing hangs like this
+
+Do not raise the timeout. Bound the failure instead (`bail` on first session
+failure) so the job produces a transcript in ~1 minute rather than burning the
+cap; the difference between "hangs" and "times out at exactly
+`connectionRetryTimeout`" is the whole diagnosis.

--- a/e2e-tauri/README.md
+++ b/e2e-tauri/README.md
@@ -4,11 +4,11 @@ A smoke suite that launches the built Tauri binary and drives it via WebDriver. 
 
 ## Platform support
 
-| OS | Supported | Notes |
-|---|---|---|
-| Linux | yes | Uses WebKitGTK via `webkit2gtk-driver` |
-| Windows | yes | Uses WebView2 via `msedgedriver` (matched to installed Edge) |
-| macOS | **no** | `tauri-driver` has no WKWebView driver. See project issue tracker. |
+| OS      | Supported | Notes                                                              |
+| ------- | --------- | ------------------------------------------------------------------ |
+| Linux   | yes       | Uses WebKitGTK via `webkit2gtk-driver`                             |
+| Windows | yes       | Uses WebView2 via `msedgedriver` (matched to installed Edge)       |
+| macOS   | **no**    | `tauri-driver` has no WKWebView driver. See project issue tracker. |
 
 ## One-time setup
 
@@ -25,13 +25,21 @@ sudo apt-get install -y webkit2gtk-driver
 ## Running locally
 
 ```bash
-# 1. Build frontend + Tauri debug binary
-bun run build
-cargo build --manifest-path src-tauri/Cargo.toml
+# 1. Build the Tauri debug binary with the frontend embedded
+bun run tauri build --debug --no-bundle
 
 # 2. Run the smoke suite
 bun run test:e2e:tauri
 ```
+
+Build through the Tauri CLI, **not** `cargo build`. A bare cargo debug build
+omits the `tauri/custom-protocol` feature, so the binary serves `build.devUrl`
+(localhost:1420) and the suite silently depends on a Vite dev server running
+alongside it. That coupling is what made the Windows CI leg hang for a month
+(#457): the webview's first paint blocks on a cold dev server transforming the
+whole module graph, and msedgedriver's `POST /session` waits for that load. Once
+the graph outgrew WDIO's 60s `connectionRetryTimeout` the handshake never
+returned. `--debug` embeds the frontend, so there is no dev server to race.
 
 ## CI
 

--- a/e2e-tauri/wdio.conf.ts
+++ b/e2e-tauri/wdio.conf.ts
@@ -4,6 +4,8 @@ import path from "node:path";
 import os from "node:os";
 import { fileURLToPath } from "node:url";
 
+// ADR 0006: Tauri E2E driver lifecycle.
+
 const here = path.dirname(fileURLToPath(import.meta.url));
 const isWindows = process.platform === "win32";
 const binaryName = isWindows ? "tauri-explorer.exe" : "tauri-explorer";

--- a/e2e-tauri/wdio.conf.ts
+++ b/e2e-tauri/wdio.conf.ts
@@ -1,3 +1,5 @@
+/// <reference types="@wdio/types" />
+
 import { spawn, type ChildProcess } from "node:child_process";
 import { createWriteStream, mkdirSync, type WriteStream } from "node:fs";
 import path from "node:path";
@@ -39,6 +41,13 @@ const tauriDriverArgs = nativeDriver ? ["--native-driver", nativeDriver] : [];
 let tauriDriver: ChildProcess | undefined;
 let driverLog: WriteStream | undefined;
 
+type TauriE2eConfig = WebdriverIO.Config & {
+  autoCompileOpts: {
+    autoCompile: boolean;
+    tsNodeOpts: { project: string; transpileOnly: boolean };
+  };
+};
+
 function recordDriverOutput(
   stream: NodeJS.ReadableStream,
   destination: NodeJS.WriteStream,
@@ -49,7 +58,7 @@ function recordDriverOutput(
   });
 }
 
-export const config: WebdriverIO.Config = {
+export const config: TauriE2eConfig = {
   runner: "local",
   specs: ["./specs/**/*.spec.ts"],
   maxInstances: 1,
@@ -101,7 +110,7 @@ export const config: WebdriverIO.Config = {
         `[tauri-e2e] driver spawn failed: ${error.stack ?? error.message}\n`,
       );
     });
-    tauriDriver.once("exit", (code, signal) => {
+    tauriDriver.once("close", (code, signal) => {
       const message = `[tauri-e2e] driver exited code=${code} signal=${signal}\n`;
       console.info(message.trim());
       driverLog?.end(message);

--- a/e2e-tauri/wdio.conf.ts
+++ b/e2e-tauri/wdio.conf.ts
@@ -1,4 +1,5 @@
 import { spawn, type ChildProcess } from "node:child_process";
+import { createWriteStream, mkdirSync, type WriteStream } from "node:fs";
 import path from "node:path";
 import os from "node:os";
 import { fileURLToPath } from "node:url";
@@ -34,6 +35,17 @@ const nativeDriver =
 const tauriDriverArgs = nativeDriver ? ["--native-driver", nativeDriver] : [];
 
 let tauriDriver: ChildProcess | undefined;
+let driverLog: WriteStream | undefined;
+
+function recordDriverOutput(
+  stream: NodeJS.ReadableStream,
+  destination: NodeJS.WriteStream,
+) {
+  stream.on("data", (chunk: Buffer) => {
+    destination.write(chunk);
+    driverLog?.write(chunk);
+  });
+}
 
 export const config: WebdriverIO.Config = {
   runner: "local",
@@ -49,8 +61,12 @@ export const config: WebdriverIO.Config = {
       "tauri:options": { application },
     } as WebdriverIO.Capabilities,
   ],
+  // Keep the normal suite exhaustive. The Windows diagnostic run sets this to
+  // stop after the first session-start failure, which makes the real timeout
+  // and the driver transcript available instead of consuming the job cap.
+  bail: process.env.TAURI_E2E_DIAGNOSTIC === "1" ? 1 : 0,
   logLevel: "info",
-  bail: 0,
+  outputDir: "./e2e-tauri/logs",
   waitforTimeout: 15_000,
   connectionRetryTimeout: 60_000,
   connectionRetryCount: 3,
@@ -65,12 +81,33 @@ export const config: WebdriverIO.Config = {
   },
 
   beforeSession: () => {
+    mkdirSync(path.join(here, "logs"), { recursive: true });
+    driverLog = createWriteStream(
+      path.join(here, "logs", `driver-${process.pid}.log`),
+    );
+    console.info(`[tauri-e2e] spawning driver for ${application}`);
     tauriDriver = spawn(tauriDriverBin, tauriDriverArgs, {
-      stdio: [null, process.stdout, process.stderr],
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    if (tauriDriver.stdout)
+      recordDriverOutput(tauriDriver.stdout, process.stdout);
+    if (tauriDriver.stderr)
+      recordDriverOutput(tauriDriver.stderr, process.stderr);
+    tauriDriver.once("error", (error) => {
+      console.error(`[tauri-e2e] driver spawn failed: ${error.message}`);
+      driverLog?.write(
+        `[tauri-e2e] driver spawn failed: ${error.stack ?? error.message}\n`,
+      );
+    });
+    tauriDriver.once("exit", (code, signal) => {
+      const message = `[tauri-e2e] driver exited code=${code} signal=${signal}\n`;
+      console.info(message.trim());
+      driverLog?.end(message);
     });
   },
 
   afterSession: () => {
+    console.info("[tauri-e2e] stopping driver after session teardown");
     tauriDriver?.kill();
   },
 };

--- a/src/lib/api/files.ts
+++ b/src/lib/api/files.ts
@@ -17,6 +17,7 @@ import {
 } from "./common";
 import { providerFor } from "$lib/plugins/fs-providers";
 import { logFrontendDiagnostic } from "./frontend-log";
+import { e2eMode } from "$lib/e2e-mode";
 
 interface DirectoryListingE2EProbe {
   targetPath: string;
@@ -29,7 +30,7 @@ interface DirectoryListingE2EProbe {
 let directoryListingE2EProbe: DirectoryListingE2EProbe | null = null;
 
 function publishReadyDirectoryWatch(path: string): void {
-  if (!import.meta.env.DEV || typeof document === "undefined") return;
+  if (!e2eMode || typeof document === "undefined") return;
   const encoded = document.documentElement.dataset.e2eReadyDirectoryWatches;
   const readyPaths: string[] = encoded ? JSON.parse(encoded) : [];
   if (!readyPaths.includes(path)) readyPaths.push(path);
@@ -37,7 +38,7 @@ function publishReadyDirectoryWatch(path: string): void {
 }
 
 function publishDirectoryListingE2EProbe(): void {
-  if (!import.meta.env.DEV || typeof document === "undefined") return;
+  if (!e2eMode || typeof document === "undefined") return;
   if (directoryListingE2EProbe) {
     document.documentElement.dataset.e2eDirectoryListingProbe = JSON.stringify({
       calls: directoryListingE2EProbe.calls,
@@ -51,9 +52,9 @@ function publishDirectoryListingE2EProbe(): void {
 
 // WebKitWebDriver evaluates injected scripts in an isolated JavaScript world,
 // so replacing window.__TAURI_INTERNALS__.invoke there cannot instrument the
-// application's Tauri calls. This dev-only DOM event crosses that boundary and
+// application's Tauri calls. This E2E-only DOM event crosses that boundary and
 // configures deterministic timing around the real backend listing invocation.
-if (import.meta.env.DEV && typeof window !== "undefined") {
+if (e2eMode && typeof window !== "undefined") {
   window.addEventListener("e2e-directory-listing-probe", ((
     event: CustomEvent<{ targetPath?: string; delays?: number[] }>,
   ) => {
@@ -566,7 +567,7 @@ export async function startStreamingDirectory(
   }
 
   const e2eProbe =
-    import.meta.env.DEV && directoryListingE2EProbe?.targetPath === path
+    e2eMode && directoryListingE2EProbe?.targetPath === path
       ? directoryListingE2EProbe
       : null;
   const e2eCallIndex = e2eProbe?.calls ?? -1;

--- a/src/lib/composables/use-file-watchers.ts
+++ b/src/lib/composables/use-file-watchers.ts
@@ -11,6 +11,7 @@ import { initFileChangeListener, cleanupFileChangeListener } from "$lib/state/fi
 import { requestRefresh, cancelPendingRefreshes } from "$lib/state/refresh-manager";
 import { settingsStore } from "$lib/state/settings.svelte";
 import { gitStatusStore } from "$lib/state/git-status.svelte";
+import { e2eMode } from "$lib/e2e-mode";
 
 export interface FileWatcherDeps {
   getAllExplorers: () => ExplorerInstance[];
@@ -24,12 +25,12 @@ interface WatcherReceipt {
 const watcherReceipts = new Map<string, WatcherReceipt>();
 
 function publishWatcherListenerReady(): void {
-  if (!import.meta.env.DEV || typeof document === "undefined") return;
+  if (!e2eMode || typeof document === "undefined") return;
   document.documentElement.dataset.e2eDirectoryWatcherListenerReady = "true";
 }
 
 function publishWatcherReceipt(path: string, observedAt: number | undefined): void {
-  if (!import.meta.env.DEV || typeof document === "undefined") return;
+  if (!e2eMode || typeof document === "undefined") return;
   const previous = watcherReceipts.get(path);
   watcherReceipts.set(path, {
     count: (previous?.count ?? 0) + 1,

--- a/src/lib/e2e-mode.ts
+++ b/src/lib/e2e-mode.ts
@@ -1,0 +1,15 @@
+/** Build-time environment needed to decide whether Tauri E2E hooks are present. */
+export interface E2EModeEnvironment {
+  DEV: boolean;
+  VITE_TAURI_E2E?: string;
+}
+
+/**
+ * Development has hooks by default. The embedded real-binary smoke build opts
+ * in explicitly; ordinary production builds never include the hooks.
+ */
+export function isE2EMode(environment: E2EModeEnvironment): boolean {
+  return environment.DEV || environment.VITE_TAURI_E2E === "1";
+}
+
+export const e2eMode = isE2EMode(import.meta.env);

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -47,6 +47,7 @@ import { windowSizeStore } from "$lib/state/window-size.svelte";
   import { conflictResolver } from "$lib/state/conflict-resolver.svelte";
   import { gitStatusStore } from "$lib/state/git-status.svelte";
   import { initTabTransferListener } from "$lib/state/tab-transfer";
+  import { e2eMode } from "$lib/e2e-mode";
   import StatusBar from "$lib/components/StatusBar.svelte";
   import AnimatedBackground from "$lib/components/AnimatedBackground.svelte";
   import MillerColumns from "$lib/components/MillerColumns.svelte";
@@ -493,13 +494,14 @@ import { windowSizeStore } from "$lib/state/window-size.svelte";
     // Apply edits made to settings.json / user themes outside the app (#599).
     const stopConfigWatch = startConfigWatch();
 
-    // Dev-only e2e hooks: the tauri-driver suite runs against the vite dev
-    // server under Xvfb with no window manager, where autofocused inline
+    // E2E-only hooks: the tauri-driver suite runs against the embedded frontend
+    // under Xvfb with no window manager, where autofocused inline
     // inputs (address bar, new-folder, rename) blur — and cancel — the
     // instant they open. These hooks drive the SAME real backend operations
     // (navigate / create_directory / rename_entry / trash) the UI flows do,
-    // just without the headless-only focus race. Absent from production.
-    if (import.meta.env.DEV) {
+    // just without the headless-only focus race. The CI build opts in with
+    // VITE_TAURI_E2E=1; ordinary production builds omit them.
+    if (e2eMode) {
       window.addEventListener("e2e-navigate", ((
         e: CustomEvent<string | { path: string; token?: string }>,
       ) => {

--- a/tests/e2e-mode.test.ts
+++ b/tests/e2e-mode.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { isE2EMode } from "$lib/e2e-mode";
+
+describe("Tauri E2E build mode", () => {
+  it("enables real-binary test hooks in the embedded smoke build", () => {
+    expect(isE2EMode({ DEV: false, VITE_TAURI_E2E: "1" })).toBe(true);
+  });
+
+  it("keeps real-binary test hooks out of normal production builds", () => {
+    expect(isE2EMode({ DEV: false })).toBe(false);
+  });
+});

--- a/tests/wdio-driver-lifecycle.test.ts
+++ b/tests/wdio-driver-lifecycle.test.ts
@@ -41,7 +41,8 @@ describe("Tauri driver lifecycle", () => {
   });
 
   it("keeps the driver transcript open until its output streams close", () => {
-    config.beforeSession?.();
+    const beforeSession = config.beforeSession as () => void;
+    beforeSession();
 
     harness.child.emit("exit", 0, null);
     expect(harness.driverLog.end).not.toHaveBeenCalled();

--- a/tests/wdio-driver-lifecycle.test.ts
+++ b/tests/wdio-driver-lifecycle.test.ts
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const harness = vi.hoisted(() => {
+  const listeners: Record<string, (...args: unknown[]) => void> = {};
+  const child = {
+    emit(event: string, ...args: unknown[]) {
+      listeners[event]?.(...args);
+    },
+    once: vi.fn((event: string, listener: (...args: unknown[]) => void) => {
+      listeners[event] = listener;
+    }),
+    stderr: { on: vi.fn() },
+    stdout: { on: vi.fn() },
+  } as {
+    emit(event: string, ...args: unknown[]): void;
+    once: ReturnType<typeof vi.fn>;
+    stderr: { on: ReturnType<typeof vi.fn> };
+    stdout: { on: ReturnType<typeof vi.fn> };
+  };
+
+  return {
+    child,
+    driverLog: { end: vi.fn(), write: vi.fn() },
+    spawn: vi.fn(() => child),
+  };
+});
+
+vi.mock("node:child_process", () => ({ spawn: harness.spawn }));
+vi.mock("node:fs", () => ({
+  createWriteStream: vi.fn(() => harness.driverLog),
+  mkdirSync: vi.fn(),
+}));
+
+const { config } = await import("../e2e-tauri/wdio.conf");
+
+describe("Tauri driver lifecycle", () => {
+  beforeEach(() => {
+    harness.driverLog.end.mockClear();
+    harness.driverLog.write.mockClear();
+    harness.spawn.mockClear();
+  });
+
+  it("keeps the driver transcript open until its output streams close", () => {
+    config.beforeSession?.();
+
+    harness.child.emit("exit", 0, null);
+    expect(harness.driverLog.end).not.toHaveBeenCalled();
+
+    harness.child.emit("close", 0, null);
+    expect(harness.driverLog.end).toHaveBeenCalledWith(
+      "[tauri-e2e] driver exited code=0 signal=null\n",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Builds the smoke binary through the Tauri CLI with its frontend embedded, eliminating the Windows WebView2 session→Vite-dev-server coupling. The explicitly opted-in smoke build retains its test-only DOM hooks, so the real-binary suite continues to drive and observe real backend operations; ordinary production builds omit them. The workflow restores automatic Windows execution, allows up to 15 minutes for the full serial Windows smoke suite, and gives the 45-minute job enough room for setup plus post-timeout diagnostics. Driver transcript capture closes only after its output streams drain, preserving final driver messages.

Driver ownership, termination, stream logging, and failure behavior follow [ADR 0006](docs/adr/0006-tauri-e2e-driver-lifecycle.md).

## Acceptance Criteria

- [ ] Push and pull-request runs execute the Tauri smoke workflow on both `ubuntu-latest` and `windows-latest`.
- [ ] The Windows smoke binary embeds the built frontend, so its first WebDriver session does not depend on a Vite dev server.
- [ ] The explicitly opted-in embedded smoke frontend exposes its test hooks, while an ordinary production build does not.
- [ ] A passing Windows smoke suite can use up to 15 minutes; if the smoke step fails or exceeds that limit, the 45-minute job retains time to upload the embedded-build output, WDIO worker logs, and a complete tauri-driver transcript.

## Test Plan

- `bunx vitest run tests/e2e-mode.test.ts tests/wdio-driver-lifecycle.test.ts`
- `bun run check`
- `VITE_TAURI_E2E=1 bun run tauri build --debug --no-bundle` — completed locally; the embedded frontend contains `e2eHooksReady`.
- `python3 docs/code-map/validate.py --coverage`
- Windows CI: confirm the full smoke suite completes within 15 minutes, or inspect the uploaded `wdio-logs-windows-latest` artifact after a bounded failure.

Fixes #457