### PR TITLE
chore: group Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,15 +5,27 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    groups:
+      routine-dependencies:
+        patterns:
+          - "*"
 
   - package-ecosystem: "cargo"
     directory: "/src-tauri"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    groups:
+      routine-dependencies:
+        patterns:
+          - "*"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    groups:
+      routine-dependencies:
+        patterns:
+          - "*"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,7 @@ Rules that bite:
 - Branch ↔ issue convention: branch `feat/my-feature` must match an **open GitHub issue** whose title contains `my-feature`; a hook validates this at branch creation. Prefixes: `feat/`, `fix/`, `refactor/`, `docs/`, `test/`, `chore/`.
 - Relationship tooling (blocking, sub-issues) is the `jwilger/gh-issue-ext` extension (`gh issue-ext …`).
 - Issue bodies need a `## Screenshots` section with checkboxes; files go in `screenshots/<branch>/` and the merge hook verifies they exist. "None required" is only for changes with no user-visible effect; behavioral fixes still need one showing the corrected behavior. Verify a screenshot actually demonstrates the feature before counting it.
+- Keep `evidence/` available for committed image-only PR acceptance proof: the automated review gate renders those files directly from the PR. It is distinct from issue screenshots, so do not add a blanket `evidence/` ignore rule.
 - The merge hook does **not** close issues — close them yourself (`gh issue close N --comment`) when the work lands on dev.
 - Before ending a session that merged UI work: `ALL_VIEW_MODES=1 npx playwright test`.
 

--- a/tests/repo-hygiene.test.ts
+++ b/tests/repo-hygiene.test.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const readRepositoryFile = (path: string) =>
+  readFileSync(new URL(`../${path}`, import.meta.url), "utf8");
+
+describe("public repository hygiene", () => {
+  it("groups routine Dependabot updates once per configured ecosystem", () => {
+    const dependabot = readRepositoryFile(".github/dependabot.yml");
+
+    for (const ecosystem of ["npm", "cargo", "github-actions"]) {
+      expect(dependabot).toMatch(
+        new RegExp(
+          `package-ecosystem: "${ecosystem}"[\\s\\S]*?groups:[\\s\\S]*?routine-dependencies:[\\s\\S]*?patterns:[\\s\\S]*?- "\\*"`,
+        ),
+      );
+    }
+  });
+
+  it("keeps committed visual proof eligible for review", () => {
+    const gitignore = readRepositoryFile(".gitignore");
+
+    expect(gitignore).not.toMatch(/^\/?evidence\/?$/m);
+  });
+});

--- a/tests/repo-hygiene.test.ts
+++ b/tests/repo-hygiene.test.ts
@@ -7,12 +7,13 @@ const readRepositoryFile = (path: string) =>
 describe("public repository hygiene", () => {
   it("groups routine Dependabot updates once per configured ecosystem", () => {
     const dependabot = readRepositoryFile(".github/dependabot.yml");
+    const updates = dependabot.split(/^  - package-ecosystem: /m).slice(1);
 
     for (const ecosystem of ["npm", "cargo", "github-actions"]) {
-      expect(dependabot).toMatch(
-        new RegExp(
-          `package-ecosystem: "${ecosystem}"[\\s\\S]*?groups:[\\s\\S]*?routine-dependencies:[\\s\\S]*?patterns:[\\s\\S]*?- "\\*"`,
-        ),
+      const update = updates.find((entry) => entry.startsWith(`"${ecosystem}"`));
+
+      expect(update).toMatch(
+        /groups:\n      routine-dependencies:\n        patterns:\n          - "\*"/,
       );
     }
   });

--- a/tests/repo-hygiene.test.ts
+++ b/tests/repo-hygiene.test.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
@@ -19,8 +20,13 @@ describe("public repository hygiene", () => {
   });
 
   it("keeps committed visual proof eligible for review", () => {
-    const gitignore = readRepositoryFile(".gitignore");
+    const projectRoot = new URL("../", import.meta.url);
+    const result = spawnSync(
+      "git",
+      ["check-ignore", "--quiet", "--no-index", "evidence/ac-proof.png"],
+      { cwd: projectRoot, stdio: "ignore" },
+    );
 
-    expect(gitignore).not.toMatch(/^\/?evidence\/?$/m);
+    expect(result.status).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary

Groups routine Dependabot updates by ecosystem while preserving existing evidence and topics.

## Acceptance Criteria

- [ ] Routine npm dependency updates arrive in one grouped Dependabot PR.
- [ ] Routine Cargo dependency updates arrive in one grouped Dependabot PR.
- [ ] Routine GitHub Actions dependency updates arrive in one grouped Dependabot PR.
- [ ] Committed PNG acceptance proof remains eligible under evidence/.
- [ ] Existing repository topics remain available to GitHub visitors.

## Verification

- bun run test passed.
- Dependabot YAML parsed successfully.
- Repository topics were verified through GitHub.

## Review

Independent adversarial review found a Git ignore test seam gap; the scoped verifier passed the correction using Git ignore semantics. No ADR governs the changed paths.

Fixes #636