### PR TITLE
fix(ci): restore Windows Tauri smoke coverage

### DIFF
--- a/.github/workflows/e2e-tauri.yml
+++ b/.github/workflows/e2e-tauri.yml
@@ -10,18 +10,12 @@ on:
 # Note: macOS is deliberately omitted. Official `tauri-driver` has no
 # WKWebView support (tauri-apps/tauri#7068). Re-add when a stable driver
 # exists or if macOS regressions justify the CrabNebula subscription.
-# The windows-latest leg still fails at msedgedriver's WebView2 attach —
-# POST /session times out while the app itself boots fine (#457; refuted so
-# far: tauri-driver release, dev-server cold start, second warm-window
-# WebView2, stdout pipe blocking, log volume). Until that is fixed it runs on
-# manual dispatch only; Windows coverage is a local run on real hardware:
-# pull on the Windows machine and `bun run test:e2e:tauri`.
 jobs:
   smoke:
     strategy:
       fail-fast: false
       matrix:
-        os: ${{ github.event_name == 'workflow_dispatch' && fromJSON('["ubuntu-latest", "windows-latest"]') || fromJSON('["ubuntu-latest"]') }}
+        os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     # The Windows debug build alone is ~12 minutes, so a 25-minute job cap left
     # no room for a full suite run: a step bound generous enough to let the
@@ -69,9 +63,10 @@ jobs:
             libwebkit2gtk-4.1-dev libgtk-3-dev libsoup-3.0-dev \
             libjavascriptcoregtk-4.1-dev webkit2gtk-driver xvfb nasm
 
-      # Install unconditionally and fail loudly: a missing binary surfaces
-      # here, not as an opaque ENOENT when wdio spawns it. Verify it lands.
+      # Linux uses tauri-driver as its WebDriver proxy. Windows attaches
+      # msedgedriver directly to the WebView2 CDP endpoint below.
       - name: Install tauri-driver
+        if: runner.os == 'Linux'
         shell: bash
         run: |
           cargo install tauri-driver --locked
@@ -125,7 +120,7 @@ jobs:
           Expand-Archive edgedriver.zip -DestinationPath "$env:RUNNER_TEMP\edgedriver"
           "TAURI_NATIVE_DRIVER=$env:RUNNER_TEMP\edgedriver\msedgedriver.exe" >> $env:GITHUB_ENV
 
-      # Bounded well below the 25-minute job cap so a regression leaves time for
+      # Bounded well below the 40-minute job cap so a regression leaves time for
       # the artifact upload below instead of being killed by the cap with
       # nothing to show. Sized for a real run, not for the fast-fail path: the
       # Linux leg's whole job is ~10 minutes, so anything near the ~1 minute a

--- a/.github/workflows/e2e-tauri.yml
+++ b/.github/workflows/e2e-tauri.yml
@@ -101,7 +101,11 @@ jobs:
         shell: bash
         env:
           VITE_E2E_HOOKS: "1"
-        run: bun run tauri build --debug --no-bundle
+          # The attach feature passes the CDP flag through WebView2's API.
+          # Environment overrides are ignored because hosted runners are
+          # elevated. Warm priming is disabled to keep one WebView2 context.
+          VITE_E2E_NO_WARM_PRIME: ${{ runner.os == 'Windows' && '1' || '' }}
+        run: bun run tauri build --debug --no-bundle ${{ runner.os == 'Windows' && '--features e2e-webview2-attach' || '' }}
 
       - name: Run smoke suite (Linux, under Xvfb)
         if: runner.os == 'Linux'
@@ -129,6 +133,8 @@ jobs:
       - name: Run smoke suite (Windows)
         if: runner.os == 'Windows'
         timeout-minutes: 15
+        env:
+          VITE_E2E_NO_WARM_PRIME: "1"
         run: bun run test:e2e:tauri
 
       - name: Upload WDIO logs

--- a/docs/lessons/457-windows-tauri-smoke-hang.md
+++ b/docs/lessons/457-windows-tauri-smoke-hang.md
@@ -1,4 +1,4 @@
-# #457 — Windows smoke hang: what got fixed, what got refuted (issue still open)
+# #457 — Windows smoke hang: elevated WebView2 ignored the debug override
 
 ## Symptom
 
@@ -51,6 +51,35 @@ The break window `8fbb2a86..71a53c38` contains exactly one commit (#424, the
 gitstat logging), yet both mechanisms tried for it are refuted. Treat that
 single-commit window as an unexplained coincidence, not as evidence.
 
+## Root cause and fix
+
+The first attach probe used Microsoft's documented
+`WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS=--remote-debugging-port=9222` approach,
+but its own evidence showed that port 9222 never opened. The missing condition
+was process integrity: GitHub's hosted Windows runner launches the app elevated,
+and WebView2 ignores user-controlled `WEBVIEW2_*` environment overrides for an
+elevated host.
+
+The fixed harness passes `--remote-debugging-port=<dynamic-port>`
+programmatically through Tauri/WRY's `additional_browser_args` API. A dedicated
+`e2e-webview2-attach` Cargo feature gates that code, so shipped builds cannot
+expose the port. On Windows, WDIO now:
+
+1. reserves a loopback port;
+2. launches the app with the chosen port;
+3. waits for WebView2's CDP endpoint;
+4. launches the runtime-matched `msedgedriver` directly; and
+5. creates a `webview2` session with `ms:edgeOptions.debuggerAddress`.
+
+Warm-window priming is disabled on this leg because JS-created WebViews cannot
+set Tauri's `additionalBrowserArgs`, and WebViews sharing a data directory must
+use identical browser arguments. Linux retains `warm-window.spec` coverage.
+
+GitHub Actions run `31436674920` verified the result on `windows-latest`: the
+first session was created in about 1.4 seconds and all 13 enabled spec files
+passed in 1m20s. The Ubuntu leg also passed. Windows was then restored to the
+normal pull-request and `dev`/`main` push matrix.
+
 ## What DID get fixed along the way (merged; Ubuntu-verified)
 
 **The suite no longer needs a dev server.** The smoke binary was built with
@@ -92,14 +121,8 @@ run, leaving the `always()` artifact upload alive.
   image update — before instrumenting the app. Two of five hypotheses died in
   one HTTP request each.
 
-## Where the hunt stands
+## Final state
 
-Everything app-side is exonerated; the failure lives in msedgedriver's attach
-(or the runner's WebView2/driver pairing — the runner image updated in the
-same July window). Next probes, in order of information value: plain headless
-Edge with no app (if that hangs, the runner pairing is broken and the app was
-never at fault); msedgedriver spoken to directly with Microsoft's documented
-WebView2 capabilities and `--verbose --log-path` for the driver's own account;
-the documented "attach" approach via `WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS`
-remote-debugging-port. A local Windows machine turns each iteration from ~25
-CI minutes into seconds.
+Windows runs on every pull request and every push to `dev`/`main`. If session
+creation regresses, inspect `e2e-tauri/logs/msedgedriver.log`; do not restore the
+environment-variable override on elevated hosted runners.

--- a/e2e-tauri/README.md
+++ b/e2e-tauri/README.md
@@ -1,4 +1,4 @@
-# Tauri-binary E2E (`tauri-driver` + WebdriverIO)
+# Tauri-binary E2E (WebdriverIO)
 
 A smoke suite that launches the built Tauri binary and drives it via WebDriver. Complements the Playwright suite in `../e2e/`, which runs against the browser dev server with mocked IPC and cannot catch issues that only surface in the real WebView.
 
@@ -6,20 +6,21 @@ A smoke suite that launches the built Tauri binary and drives it via WebDriver. 
 
 | OS      | Supported | Notes                                                              |
 | ------- | --------- | ------------------------------------------------------------------ |
-| Linux   | yes       | Uses WebKitGTK via `webkit2gtk-driver`                             |
-| Windows | yes       | Uses WebView2 via `msedgedriver` (matched to installed Edge)       |
+| Linux   | yes       | Uses `tauri-driver` + WebKitGTK                                    |
+| Windows | yes       | Attaches `msedgedriver` to WebView2 through an E2E-only CDP port   |
 | macOS   | **no**    | `tauri-driver` has no WKWebView driver. See project issue tracker. |
 
 ## One-time setup
 
 ```bash
-# Binary: tauri-driver (installs to ~/.cargo/bin/)
+# Linux only: tauri-driver (installs to ~/.cargo/bin/)
 cargo install tauri-driver --locked
 
 # Linux only: WebKitWebDriver
 sudo apt-get install -y webkit2gtk-driver
 
-# Windows only: msedgedriver must be on PATH (pre-installed on windows-latest CI runners)
+# Windows only: download msedgedriver matching the installed WebView2 runtime
+# and set TAURI_NATIVE_DRIVER to its full path.
 ```
 
 ## Running locally
@@ -40,14 +41,17 @@ asset path with no dev server in the loop. The suite's test hooks are compiled
 in with `VITE_E2E_HOOKS=1` at build time (see `src/lib/domain/e2e-hooks.ts`);
 without it every spec fails with "dev e2e hooks never became ready".
 
+Windows additionally builds with `--features e2e-webview2-attach`, sets
+`VITE_E2E_NO_WARM_PRIME=1`, and runs with `TAURI_NATIVE_DRIVER` pointing to a
+driver that matches the WebView2 runtime. That Cargo feature is intentionally
+absent from release builds: it is the only path that exposes a CDP port.
+
 ## CI
 
 See `.github/workflows/e2e-tauri.yml`. Runs on `pull_request` and `push` to
-`dev`/`main` against `ubuntu-latest`. The `windows-latest` leg is manual
-dispatch only until #457 is fixed — msedgedriver's WebView2 attach times out
-while the app itself boots fine; `docs/lessons/457-windows-tauri-smoke-hang.md`
-records which hypotheses are already refuted. Windows coverage is a local run
-on real hardware instead.
+`dev`/`main` against both `ubuntu-latest` and `windows-latest`.
+`docs/lessons/457-windows-tauri-smoke-hang.md` records why the Windows harness
+must use the programmatic CDP attach path.
 
 ## Adding specs
 

--- a/e2e-tauri/specs/terminal.spec.ts
+++ b/e2e-tauri/specs/terminal.spec.ts
@@ -30,7 +30,12 @@ async function sendTerminalCommand(
     timeout: 2_000,
     timeoutMsg: "xterm input never received focus",
   });
-  await input.addValue(command);
+  // msedgedriver can deliver a multi-character element Send Keys payload to
+  // xterm/ConPTY out of order. Awaiting one WebDriver command per character
+  // gives the terminal an ordering boundary between key events.
+  for (const character of command) {
+    await browser.keys(character);
+  }
   await browser.keys("Enter");
 }
 

--- a/e2e-tauri/specs/terminal.spec.ts
+++ b/e2e-tauri/specs/terminal.spec.ts
@@ -21,6 +21,19 @@ async function terminalText(): Promise<string> {
   return domText(".terminal-panel .xterm-rows");
 }
 
+async function sendTerminalCommand(
+  input: ReturnType<typeof $>,
+  command: string,
+): Promise<void> {
+  await browser.execute((element: HTMLElement) => element.focus(), input);
+  await browser.waitUntil(() => input.isFocused(), {
+    timeout: 2_000,
+    timeoutMsg: "xterm input never received focus",
+  });
+  await input.addValue(command);
+  await browser.keys("Enter");
+}
+
 describe("embedded terminal", () => {
   it("opens with Ctrl+` and shows a live shell", async () => {
     await $(".file-list").waitForExist({ timeout: 15_000 });
@@ -37,9 +50,8 @@ describe("embedded terminal", () => {
   });
 
   it("round-trips input: a typed command executes and its output appears", async () => {
-    // Focus is already in the terminal after opening; type via the helper
-    // textarea xterm maintains.
-    const input = $(".terminal-panel textarea.xterm-helper-textarea");
+    // Type through the helper textarea xterm maintains.
+    const input = await $(".terminal-panel textarea.xterm-helper-textarea");
     await input.waitForExist();
 
     // Never type into a shell that hasn't prompted yet — keystrokes sent
@@ -58,22 +70,19 @@ describe("embedded terminal", () => {
       return text.split(marker).length >= 3;
     };
 
-    await input.addValue(`echo ${marker}\n`);
-    try {
-      await browser.waitUntil(markerEchoed, { timeout: 20_000 });
-    } catch {
-      // First keystrokes can still be lost right at prompt time — one retry.
-      await input.addValue(`echo ${marker}\n`);
-      await browser.waitUntil(markerEchoed, {
-        timeout: 20_000,
-        timeoutMsg: "echoed command output never appeared (after retry)",
-      });
-    }
+    // DOM inspection does not preserve xterm's input focus on WebView2.
+    // Establish and observe focus, then deliver Enter as a WebDriver key
+    // instead of relying on a newline embedded in element text input.
+    await sendTerminalCommand(input, `echo ${marker}`);
+    await browser.waitUntil(markerEchoed, {
+      timeout: 20_000,
+      timeoutMsg: "echoed command output never appeared",
+    });
   });
 
   it("shell starts in the explorer's current directory", async () => {
-    const input = $(".terminal-panel textarea.xterm-helper-textarea");
-    await input.addValue("pwd\n");
+    const input = await $(".terminal-panel textarea.xterm-helper-textarea");
+    await sendTerminalCommand(input, "pwd");
 
     // The app is launched with cwd = the test workspace (see wdio config);
     // pwd output must contain the explorer's path shown in the status bar.
@@ -123,9 +132,9 @@ describe("embedded terminal", () => {
       const target = mkdtempSync(join(tmpdir(), "te-cwd-"));
       await navigateTo(target);
 
-      const input = $(".terminal-panel textarea.xterm-helper-textarea");
+      const input = await $(".terminal-panel textarea.xterm-helper-textarea");
       await input.waitForExist();
-      await input.addValue("pwd\n");
+      await sendTerminalCommand(input, "pwd");
 
       await browser.waitUntil(async () => (await terminalText()).includes(target), {
         timeout: 15_000,
@@ -144,9 +153,9 @@ describe("embedded terminal", () => {
       }
       await $(".terminal-panel .xterm").waitForDisplayed({ timeout: 5_000 });
 
-      const input = $(".terminal-panel textarea.xterm-helper-textarea");
+      const input = await $(".terminal-panel textarea.xterm-helper-textarea");
       await input.waitForExist();
-      await input.addValue("cd /tmp\n");
+      await sendTerminalCommand(input, "cd /tmp");
 
       await browser.waitUntil(
         async () => (await $(".status-path").getAttribute("title")) === "/tmp",

--- a/e2e-tauri/wdio.conf.ts
+++ b/e2e-tauri/wdio.conf.ts
@@ -158,7 +158,6 @@ export const config: WebdriverIO.Config = {
         `--port=${driverPort}`,
         "--verbose",
         `--log-path=${driverLogPath}`,
-        "--allowed-ips=",
       ],
       { stdio: ["ignore", process.stdout, process.stderr] },
     );

--- a/e2e-tauri/wdio.conf.ts
+++ b/e2e-tauri/wdio.conf.ts
@@ -1,4 +1,6 @@
 import { spawn, type ChildProcess } from "node:child_process";
+import { mkdirSync } from "node:fs";
+import net from "node:net";
 import path from "node:path";
 import os from "node:os";
 import { fileURLToPath } from "node:url";
@@ -33,21 +35,74 @@ const nativeDriver =
 
 const tauriDriverArgs = nativeDriver ? ["--native-driver", nativeDriver] : [];
 
-let tauriDriver: ChildProcess | undefined;
+const driverPort = 4444;
+const driverLogPath = path.join(here, "logs", "msedgedriver.log");
+
+let driverProcess: ChildProcess | undefined;
+let applicationProcess: ChildProcess | undefined;
+
+const waitForPort = async (port: number, timeoutMs: number): Promise<boolean> => {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const reachable = await new Promise<boolean>((resolve) => {
+      const socket = net.connect(port, "127.0.0.1");
+      socket.once("connect", () => {
+        socket.destroy();
+        resolve(true);
+      });
+      socket.once("error", () => resolve(false));
+    });
+    if (reachable) return true;
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  return false;
+};
+
+const reservePort = async (): Promise<number> =>
+  new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        server.close();
+        reject(new Error("failed to allocate a WebView2 debug port"));
+        return;
+      }
+      server.close((error) => (error ? reject(error) : resolve(address.port)));
+    });
+  });
+
+const stopProcesses = (): void => {
+  driverProcess?.kill();
+  applicationProcess?.kill();
+  driverProcess = undefined;
+  applicationProcess = undefined;
+};
 
 export const config: WebdriverIO.Config = {
   runner: "local",
   specs: ["./specs/**/*.spec.ts"],
+  exclude:
+    process.env.VITE_E2E_NO_WARM_PRIME === "1"
+      ? ["./specs/warm-window.spec.ts"]
+      : [],
   maxInstances: 1,
   capabilities: [
-    {
-      // No browserName: tauri-driver fills it in for the platform's native
-      // driver. WDIO v9 defaults to WebDriver BiDi (webSocketUrl), which
-      // WebKitWebDriver/msedgedriver reject with "Failed to match
-      // capabilities" — enforce classic.
-      "wdio:enforceWebDriverClassic": true,
-      "tauri:options": { application },
-    } as WebdriverIO.Capabilities,
+    (isWindows
+      ? {
+          browserName: "webview2",
+          "ms:edgeOptions": { debuggerAddress: "127.0.0.1:0" },
+          "wdio:enforceWebDriverClassic": true,
+        }
+      : {
+          // No browserName: tauri-driver fills it in for the platform's native
+          // driver. WDIO v9 defaults to WebDriver BiDi (webSocketUrl), which
+          // WebKitWebDriver rejects with "Failed to match capabilities" —
+          // enforce classic.
+          "wdio:enforceWebDriverClassic": true,
+          "tauri:options": { application },
+        }) as WebdriverIO.Capabilities,
   ],
   logLevel: "info",
   bail: 0,
@@ -55,7 +110,7 @@ export const config: WebdriverIO.Config = {
   connectionRetryTimeout: 60_000,
   connectionRetryCount: 3,
   hostname: "127.0.0.1",
-  port: 4444,
+  port: driverPort,
   framework: "mocha",
   reporters: ["spec"],
   mochaOpts: { ui: "bdd", timeout: 60_000 },
@@ -64,13 +119,54 @@ export const config: WebdriverIO.Config = {
     tsNodeOpts: { transpileOnly: true, project: "./e2e-tauri/tsconfig.json" },
   },
 
-  beforeSession: () => {
-    tauriDriver = spawn(tauriDriverBin, tauriDriverArgs, {
-      stdio: [null, process.stdout, process.stderr],
+  beforeSession: async (_config, capabilities) => {
+    if (!isWindows) {
+      driverProcess = spawn(tauriDriverBin, tauriDriverArgs, {
+        stdio: [null, process.stdout, process.stderr],
+      });
+      return;
+    }
+
+    if (!nativeDriver) {
+      throw new Error("TAURI_NATIVE_DRIVER must point to msedgedriver.exe on Windows");
+    }
+
+    const debugPort = await reservePort();
+    const edgeOptions = (
+      capabilities as unknown as {
+        "ms:edgeOptions": Record<string, unknown>;
+      }
+    )["ms:edgeOptions"];
+    edgeOptions.debuggerAddress = `127.0.0.1:${debugPort}`;
+
+    applicationProcess = spawn(application, [], {
+      stdio: ["ignore", process.stdout, process.stderr],
+      env: {
+        ...process.env,
+        TAURI_E2E_WEBVIEW2_DEBUG_PORT: String(debugPort),
+      },
     });
+    if (!(await waitForPort(debugPort, 30_000))) {
+      stopProcesses();
+      throw new Error(`WebView2 debug port ${debugPort} did not become reachable`);
+    }
+
+    mkdirSync(path.dirname(driverLogPath), { recursive: true });
+    driverProcess = spawn(
+      nativeDriver,
+      [
+        `--port=${driverPort}`,
+        "--verbose",
+        `--log-path=${driverLogPath}`,
+        "--allowed-ips=",
+      ],
+      { stdio: ["ignore", process.stdout, process.stderr] },
+    );
+    if (!(await waitForPort(driverPort, 10_000))) {
+      stopProcesses();
+      throw new Error("msedgedriver did not start listening");
+    }
   },
 
-  afterSession: () => {
-    tauriDriver?.kill();
-  },
+  afterSession: stopProcesses,
 };

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -71,6 +71,10 @@ tauri-plugin-log = "2"
 ureq = { version = "3.3.0", default-features = false, features = ["rustls", "json"] }
 
 [features]
+# Enables the programmatic WebView2 debug port used by the Windows binary-E2E
+# harness. This must stay opt-in: release builds must not expose a CDP port.
+e2e-webview2-attach = []
+
 # AVIF thumbnails/previews, via image's avif-native decoder (system dav1d).
 # Off by default so the cross-platform release build needs no dav1d (Ubuntu
 # 22.04's is too old, and bundling it into the AppImage/deb is a headache).

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -48,6 +48,23 @@ mod terminal;
 mod thumbnails;
 mod wallpaper;
 mod warm_pool;
+
+#[cfg(all(target_os = "windows", feature = "e2e-webview2-attach"))]
+fn e2e_webview2_browser_args() -> String {
+    let port = std::env::var("TAURI_E2E_WEBVIEW2_DEBUG_PORT")
+        .expect("TAURI_E2E_WEBVIEW2_DEBUG_PORT must be set for e2e-webview2-attach");
+    let port = port
+        .parse::<u16>()
+        .expect("TAURI_E2E_WEBVIEW2_DEBUG_PORT must be a valid TCP port");
+    assert_ne!(port, 0, "TAURI_E2E_WEBVIEW2_DEBUG_PORT must not be zero");
+
+    // Calling additional_browser_args replaces WRY's defaults, so preserve
+    // them before adding the E2E-only CDP endpoint.
+    format!(
+        "--disable-features=msWebOOUI,msPdfOOUI,msSmartScreenProtection \
+         --remote-debugging-port={port}"
+    )
+}
 mod wsl;
 
 use system::{
@@ -422,6 +439,16 @@ pub fn run(launch_dir: Option<String>) {
             // background transparent so the effect shows through.
             #[cfg(target_os = "windows")]
             {
+                // GitHub's Windows runner starts the host elevated. WebView2
+                // deliberately ignores WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS
+                // in elevated processes, so the E2E harness must configure
+                // its CDP port through CoreWebView2EnvironmentOptions instead.
+                // The Cargo feature keeps this unreachable in shipped builds.
+                #[cfg(feature = "e2e-webview2-attach")]
+                {
+                    builder = builder.additional_browser_args(&e2e_webview2_browser_args());
+                }
+
                 let backdrop = config::config_dir()
                     .ok()
                     .and_then(|dir| std::fs::read_to_string(dir.join("settings.json")).ok())

--- a/src/lib/domain/e2e-hooks.ts
+++ b/src/lib/domain/e2e-hooks.ts
@@ -21,3 +21,13 @@
  */
 export const E2E_HOOKS_ENABLED =
   import.meta.env.DEV || import.meta.env.VITE_E2E_HOOKS === "1";
+
+/**
+ * Windows CI attaches msedgedriver to the main WebView2 through an E2E-only
+ * CDP port. Do not create the parked warm WebView during that suite: all
+ * WebViews sharing a WebView2 data directory must use identical browser args,
+ * while JS-created windows cannot set Tauri's additionalBrowserArgs option.
+ * Linux retains the warm-window coverage.
+ */
+export const E2E_WARM_WINDOW_PRIMING_DISABLED =
+  import.meta.env.VITE_E2E_NO_WARM_PRIME === "1";

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -6,7 +6,7 @@
   import "@fontsource-variable/inter";
   import { onMount } from "svelte";
   import { getAlwaysActiveTerminalCommandId, isShellReservedKey } from "$lib/domain/terminal-keys";
-  import { E2E_HOOKS_ENABLED } from "$lib/domain/e2e-hooks";
+  import { E2E_HOOKS_ENABLED, E2E_WARM_WINDOW_PRIMING_DISABLED } from "$lib/domain/e2e-hooks";
   import { themeStore } from "$lib/state/theme.svelte";
   import { startConfigWatch } from "$lib/state/config-watch";
   import { settingsStore } from "$lib/state/settings.svelte";
@@ -564,7 +564,7 @@ import { windowSizeStore } from "$lib/state/window-size.svelte";
     // runaway-spawn bug. Deferred so it never competes with this window's own
     // first paint; settings are read at fire time, after settingsStore.init()
     // has resolved.
-    if (wmode === "off") {
+    if (wmode === "off" && !E2E_WARM_WINDOW_PRIMING_DISABLED) {
       setTimeout(() => {
         if (settingsStore.warmWindow) void spawnWarmWindow();
       }, 1500);


### PR DESCRIPTION
## Summary
- pass the WebView2 debug port programmatically for elevated Windows runners
- attach the runtime-matched msedgedriver directly over loopback
- gate CDP exposure behind an E2E-only Cargo feature
- restore windows-latest to normal PR and dev/main CI
- serialize terminal WebDriver input after runner logs proved batched keys could reorder

## Verification
- GitHub Actions run 31440571444: windows-latest and ubuntu-latest passed on exact commit 44790b51

Closes #457