### PR TITLE
ci: cancel superseded validation runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ on:
     branches: [dev, main]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
   # Code maps are only useful while they are accurate: an agent that trusts a map
   # naming a moved file searches worse than one with no map at all. Two guards —

--- a/.github/workflows/e2e-tauri.yml
+++ b/.github/workflows/e2e-tauri.yml
@@ -7,6 +7,10 @@ on:
     branches: [dev, main]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
 # Note: macOS is deliberately omitted. Official `tauri-driver` has no
 # WKWebView support (tauri-apps/tauri#7068). Re-add when a stable driver
 # exists or if macOS regressions justify the CrabNebula subscription.

--- a/.github/workflows/macos-smoke.yml
+++ b/.github/workflows/macos-smoke.yml
@@ -9,6 +9,10 @@ on:
   pull_request:
     branches: [main, dev]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
   launch-smoke:
     runs-on: macos-latest

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -14,6 +14,10 @@ on:
       - 'e2e/tiles-scroll-perf.spec.ts'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
   perf-check:
     name: Performance Regression Check

--- a/.github/workflows/windows-installer.yml
+++ b/.github/workflows/windows-installer.yml
@@ -15,6 +15,10 @@ on:
       - README.md
       - .github/workflows/windows-installer.yml
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
   invocation:
     runs-on: windows-latest


### PR DESCRIPTION
Use a shared workflow/head-branch concurrency group for validation workflows so a PR run supersedes the redundant push run for the same branch. Also cancel stale runs after new commits. Build & Release is intentionally unchanged.