### PR TITLE
ci(release): tag the triggering commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,5 +128,6 @@ jobs:
             -o -name '*.msi' -o -name '*-setup.exe' \))
           gh release create "$VERSION" \
             --title "$VERSION" \
+            --target "$GITHUB_SHA" \
             --generate-notes \
             "${assets[@]}"


### PR DESCRIPTION
Pass GITHUB_SHA to gh release create so release tags always point to the exact main commit that produced the artifacts, rather than the repository default branch.